### PR TITLE
Wsteth rbr update

### DIFF
--- a/diffs/AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024_before_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024_after.md
+++ b/diffs/AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024_before_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024_after.md
@@ -1,0 +1,44 @@
+## Reserve changes
+
+### Reserves altered
+
+#### wstETH ([0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0](https://etherscan.io/address/0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0))
+
+| description | value before | value after |
+| --- | --- | --- |
+| maxVariableBorrowRate | 84.75 % | 82.25 % |
+| variableRateSlope1 | 4.5 % | 2 % |
+| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=45000000000000000000000000&variableRateSlope2=800000000000000000000000000&optimalUsageRatio=450000000000000000000000000&baseVariableBorrowRate=2500000000000000000000000&maxVariableBorrowRate=847500000000000000000000000) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=20000000000000000000000000&variableRateSlope2=800000000000000000000000000&optimalUsageRatio=450000000000000000000000000&baseVariableBorrowRate=2500000000000000000000000&maxVariableBorrowRate=822500000000000000000000000) |
+
+## Emodes changed
+
+### EMode: ETH correlated(id: 1)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label (unchanged) | ETH correlated | ETH correlated |
+| eMode.ltv (unchanged) | 93 % | 93 % |
+| eMode.liquidationThreshold (unchanged) | 95 % | 95 % |
+| eMode.liquidationBonus (unchanged) | 1 % | 1 % |
+| eMode.borrowableBitmap (unchanged) | WETH, wstETH, cbETH, rETH, weETH, osETH, ETHx | WETH, wstETH, cbETH, rETH, weETH, osETH, ETHx |
+| eMode.collateralBitmap (unchanged) | WETH, wstETH, cbETH, rETH, weETH, osETH, ETHx | WETH, wstETH, cbETH, rETH, weETH, osETH, ETHx |
+
+
+## Raw diff
+
+```json
+{
+  "strategies": {
+    "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": {
+      "maxVariableBorrowRate": {
+        "from": "847500000000000000000000000",
+        "to": "822500000000000000000000000"
+      },
+      "variableRateSlope1": {
+        "from": "45000000000000000000000000",
+        "to": "20000000000000000000000000"
+      }
+    }
+  }
+}
+```

--- a/diffs/AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024_before_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024_after.md
+++ b/diffs/AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024_before_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024_after.md
@@ -6,9 +6,10 @@
 
 | description | value before | value after |
 | --- | --- | --- |
-| maxVariableBorrowRate | 84.75 % | 82.25 % |
+| maxVariableBorrowRate | 84.75 % | 82 % |
+| baseVariableBorrowRate | 0.25 % | 0 % |
 | variableRateSlope1 | 4.5 % | 2 % |
-| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=45000000000000000000000000&variableRateSlope2=800000000000000000000000000&optimalUsageRatio=450000000000000000000000000&baseVariableBorrowRate=2500000000000000000000000&maxVariableBorrowRate=847500000000000000000000000) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=20000000000000000000000000&variableRateSlope2=800000000000000000000000000&optimalUsageRatio=450000000000000000000000000&baseVariableBorrowRate=2500000000000000000000000&maxVariableBorrowRate=822500000000000000000000000) |
+| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=45000000000000000000000000&variableRateSlope2=800000000000000000000000000&optimalUsageRatio=450000000000000000000000000&baseVariableBorrowRate=2500000000000000000000000&maxVariableBorrowRate=847500000000000000000000000) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=20000000000000000000000000&variableRateSlope2=800000000000000000000000000&optimalUsageRatio=450000000000000000000000000&baseVariableBorrowRate=0&maxVariableBorrowRate=820000000000000000000000000) |
 
 ## Emodes changed
 
@@ -30,9 +31,13 @@
 {
   "strategies": {
     "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": {
+      "baseVariableBorrowRate": {
+        "from": "2500000000000000000000000",
+        "to": "0"
+      },
       "maxVariableBorrowRate": {
         "from": "847500000000000000000000000",
-        "to": "822500000000000000000000000"
+        "to": "820000000000000000000000000"
       },
       "variableRateSlope1": {
         "from": "45000000000000000000000000",

--- a/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024.sol
+++ b/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV3PayloadEthereum} from 'aave-helpers/src/v3-config-engine/AaveV3PayloadEthereum.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
+/**
+ * @title wstETH Reserve Borrow Rate Update - Main Instance
+ * @author karpatkey_TokenLogic
+ * - Snapshot: Direct-to-AIP
+ * - Discussion: https://governance.aave.com/t/arfc-weth-wsteth-borrow-rate-updates/19550
+ */
+contract AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024 is
+  AaveV3PayloadEthereum
+{
+  function rateStrategiesUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.RateStrategyUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.RateStrategyUpdate[]
+      memory rateStrategies = new IAaveV3ConfigEngine.RateStrategyUpdate[](1);
+    rateStrategies[0] = IAaveV3ConfigEngine.RateStrategyUpdate({
+      asset: AaveV3EthereumAssets.wstETH_UNDERLYING,
+      params: IAaveV3ConfigEngine.InterestRateInputData({
+        optimalUsageRatio: EngineFlags.KEEP_CURRENT,
+        baseVariableBorrowRate: EngineFlags.KEEP_CURRENT,
+        variableRateSlope1: 2_00,
+        variableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+
+    return rateStrategies;
+  }
+}

--- a/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024.sol
+++ b/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024.sol
@@ -26,7 +26,7 @@ contract AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024 is
       asset: AaveV3EthereumAssets.wstETH_UNDERLYING,
       params: IAaveV3ConfigEngine.InterestRateInputData({
         optimalUsageRatio: EngineFlags.KEEP_CURRENT,
-        baseVariableBorrowRate: EngineFlags.KEEP_CURRENT,
+        baseVariableBorrowRate: 0,
         variableRateSlope1: 2_00,
         variableRateSlope2: EngineFlags.KEEP_CURRENT
       })

--- a/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024.t.sol
+++ b/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024.t.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum} from 'aave-address-book/AaveV3Ethereum.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024} from './AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024.sol';
+
+/**
+ * @dev Test for AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024
+ * command: FOUNDRY_PROFILE=mainnet forge test --match-path=src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024.t.sol -vv
+ */
+contract AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024_Test is
+  ProtocolV3TestBase
+{
+  AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21036418);
+    proposal = new AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024',
+      AaveV3Ethereum.POOL,
+      address(proposal)
+    );
+  }
+}

--- a/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/WstETHReserveBorrowRateUpdateMainInstance.md
+++ b/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/WstETHReserveBorrowRateUpdateMainInstance.md
@@ -23,7 +23,7 @@ The Main instance the wstETH Slope1 parameter is to be revised as follows:
 
 | Asset  | Parameter | Current | Proposed | Change |
 | :----: | :-------: | :-----: | :------: | :----: |
-| wstETH |  Slope1   |  4.75%  |  2.00%   | -2.75% |
+| wstETH |  Slope1   |  4.50%  |  2.00%   | -2.50% |
 
 ## References
 

--- a/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/WstETHReserveBorrowRateUpdateMainInstance.md
+++ b/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/WstETHReserveBorrowRateUpdateMainInstance.md
@@ -1,0 +1,37 @@
+---
+title: "wstETH Reserve Borrow Rate Update - Main Instance"
+author: "karpatkey_TokenLogic"
+discussions: "https://governance.aave.com/t/arfc-weth-wsteth-borrow-rate-updates/19550"
+snapshot: "Direct-to-AIP"
+---
+
+## Simple Summary
+
+This publication proposes reducing wstETH Slope1 parameter on the Main instance of Aave v3 on Ethereum.
+
+## Motivation
+
+Users with leverage long wstETH and short ETH positions are expected to generate a return exceeding pre-wstETH liquidity mining rewards being initiated.
+
+With the goal of encouraging user to borrow wstETH on the Main instance of Aave v3, the wstETH borrow rate will be lowered. The anticipated rsETH collateral and wETH debt eMode category is expected to create demand for wstETH debt. Given the size of the wstETH reserve the Uoptimal is not being increased by this propsoal.
+
+After monitoring how the market responds, future borrow rate adjustments across the Aave v3 instances on Ethereum will be assessed and any change presented for discussion.
+
+## Specification
+
+The Main instance the wstETH Slope1 parameter is to be revised as follows:
+
+| Asset  | Parameter | Current | Proposed | Change |
+| :----: | :-------: | :-----: | :------: | :----: |
+| wstETH |  Slope1   |  4.75%  |  2.00%   | -2.75% |
+
+## References
+
+- Implementation: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024.sol)
+- Tests: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024.t.sol)
+- [Snapshot](Direct-to-AIP)
+- [Discussion](https://governance.aave.com/t/arfc-weth-wsteth-borrow-rate-updates/19550)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/WstETHReserveBorrowRateUpdateMainInstance.md
+++ b/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/WstETHReserveBorrowRateUpdateMainInstance.md
@@ -19,10 +19,11 @@ After monitoring how the market responds, future borrow rate adjustments across 
 
 ## Specification
 
-The Main instance the wstETH Slope1 parameter is to be revised as follows:
+The Main instance the wstETH Slope1 and base parameter is to be revised as follows:
 
 | Asset  | Parameter | Current | Proposed | Change |
 | :----: | :-------: | :-----: | :------: | :----: |
+| wstETH |   Base    |  0.25%  |  0.00%   | -0.25% |
 | wstETH |  Slope1   |  4.50%  |  2.00%   | -2.50% |
 
 ## References

--- a/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/WstETHReserveBorrowRateUpdateMainInstance.md
+++ b/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/WstETHReserveBorrowRateUpdateMainInstance.md
@@ -11,9 +11,9 @@ This publication proposes reducing wstETH Slope1 parameter on the Main instance 
 
 ## Motivation
 
-Users with leverage long wstETH and short ETH positions are expected to generate a return exceeding pre-wstETH liquidity mining rewards being initiated.
+With the goal of encouraging user to borrow wstETH on the Main instance of Aave v3, the wstETH borrow rate will be lowered.
 
-With the goal of encouraging user to borrow wstETH on the Main instance of Aave v3, the wstETH borrow rate will be lowered. The anticipated rsETH collateral and wETH debt eMode category is expected to create demand for wstETH debt. Given the size of the wstETH reserve the Uoptimal is not being increased by this propsoal.
+The anticipated rsETH collateral and wETH debt eMode category is expected to create demand for wstETH debt. Given the size of the wstETH reserve the Uoptimal is not being increased by this propsoal.
 
 After monitoring how the market responds, future borrow rate adjustments across the Aave v3 instances on Ethereum will be assessed and any change presented for discussion.
 

--- a/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/WstETHReserveBorrowRateUpdateMainInstance_20241024.s.sol
+++ b/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/WstETHReserveBorrowRateUpdateMainInstance_20241024.s.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+import {EthereumScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024} from './AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * deploy-command: make deploy-ledger contract=src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/WstETHReserveBorrowRateUpdateMainInstance_20241024.s.sol:DeployEthereum chain=mainnet
+ * verify-command: FOUNDRY_PROFILE=mainnet npx catapulta-verify -b broadcast/WstETHReserveBorrowRateUpdateMainInstance_20241024.s.sol/1/run-latest.json
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/WstETHReserveBorrowRateUpdateMainInstance_20241024.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](1);
+
+    // compose actions for validation
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
+    actionsEthereum[0] = GovV3Helpers.buildAction(
+      type(AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance_20241024).creationCode
+    );
+    payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovernanceV3Ethereum.VOTING_PORTAL_ETH_POL,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/WstETHReserveBorrowRateUpdateMainInstance.md'
+      )
+    );
+  }
+}

--- a/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/config.ts
+++ b/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/config.ts
@@ -1,0 +1,31 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV3Ethereum'],
+    title: 'wstETH Reserve Borrow Rate Update - Main Instance',
+    shortName: 'WstETHReserveBorrowRateUpdateMainInstance',
+    date: '20241024',
+    author: 'karpatkey_TokenLogic',
+    discussion: 'https://governance.aave.com/t/arfc-weth-wsteth-borrow-rate-updates/19550',
+    snapshot: 'Direct-to-AIP',
+    votingNetwork: 'POLYGON',
+  },
+  poolOptions: {
+    AaveV3Ethereum: {
+      configs: {
+        RATE_UPDATE_V3: [
+          {
+            asset: 'wstETH',
+            params: {
+              optimalUtilizationRate: '',
+              baseVariableBorrowRate: '',
+              variableRateSlope1: '2.00',
+              variableRateSlope2: '',
+            },
+          },
+        ],
+      },
+      cache: {blockNumber: 21036418},
+    },
+  },
+};

--- a/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/config.ts
+++ b/src/20241024_AaveV3Ethereum_WstETHReserveBorrowRateUpdateMainInstance/config.ts
@@ -18,7 +18,7 @@ export const config: ConfigFile = {
             asset: 'wstETH',
             params: {
               optimalUtilizationRate: '',
-              baseVariableBorrowRate: '',
+              baseVariableBorrowRate: '0.00',
               variableRateSlope1: '2.00',
               variableRateSlope2: '',
             },


### PR DESCRIPTION
This PR proposes reducing wstETH Slope1 parameter on the Main instance of Aave v3 on Ethereum.

The Main instance the wstETH Slope1 and base parameter is to be revised as follows:

| Asset  | Parameter | Current | Proposed | Change |
| :----: | :-------: | :-----: | :------: | :----: |
| wstETH |   Base    |  0.25%  |  0.00%   | -0.25% |
| wstETH |  Slope1   |  4.50%  |  2.00%   | -2.50% |