### PR TITLE
Pyusd reserve config update and incentive campaign

### DIFF
--- a/diffs/AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031_before_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031_after.md
+++ b/diffs/AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031_before_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031_after.md
@@ -24,26 +24,14 @@
 | eMode.ltv (unchanged) | 93 % | 93 % |
 | eMode.liquidationThreshold (unchanged) | 95 % | 95 % |
 | eMode.liquidationBonus (unchanged) | 1 % | 1 % |
-| eMode.borrowableBitmap | WETH, wstETH, cbETH, rETH, weETH, osETH, ETHx | WETH, wstETH, cbETH, rETH, PYUSD, weETH, osETH, ETHx |
-| eMode.collateralBitmap | WETH, wstETH, cbETH, rETH, weETH, osETH, ETHx | WETH, wstETH, cbETH, rETH, PYUSD, weETH, osETH, ETHx |
+| eMode.borrowableBitmap (unchanged) | WETH, wstETH, cbETH, rETH, weETH, osETH, ETHx | WETH, wstETH, cbETH, rETH, weETH, osETH, ETHx |
+| eMode.collateralBitmap (unchanged) | WETH, wstETH, cbETH, rETH, weETH, osETH, ETHx | WETH, wstETH, cbETH, rETH, weETH, osETH, ETHx |
 
 
 ## Raw diff
 
 ```json
 {
-  "eModes": {
-    "1": {
-      "borrowableBitmap": {
-        "from": "2952790659",
-        "to": "3087008387"
-      },
-      "collateralBitmap": {
-        "from": "2952790659",
-        "to": "3087008387"
-      }
-    }
-  },
   "reserves": {
     "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8": {
       "borrowCap": {

--- a/diffs/AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031_before_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031_after.md
+++ b/diffs/AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031_before_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031_after.md
@@ -1,0 +1,76 @@
+## Reserve changes
+
+### Reserves altered
+
+#### PYUSD ([0x6c3ea9036406852006290770BEdFcAbA0e23A0e8](https://etherscan.io/address/0x6c3ea9036406852006290770BEdFcAbA0e23A0e8))
+
+| description | value before | value after |
+| --- | --- | --- |
+| borrowCap | 48,000,000 PYUSD | 15,000,000 PYUSD |
+| usageAsCollateralEnabled | false | true |
+| ltv | 0 % [0] | 75 % [7500] |
+| liquidationThreshold | 0 % [0] | 78 % [7800] |
+| liquidationBonus | 0 % | 7.5 % |
+| liquidationProtocolFee | 0 % [0] | 10 % [1000] |
+
+
+## Emodes changed
+
+### EMode: ETH correlated(id: 1)
+
+| description | value before | value after |
+| --- | --- | --- |
+| eMode.label (unchanged) | ETH correlated | ETH correlated |
+| eMode.ltv (unchanged) | 93 % | 93 % |
+| eMode.liquidationThreshold (unchanged) | 95 % | 95 % |
+| eMode.liquidationBonus (unchanged) | 1 % | 1 % |
+| eMode.borrowableBitmap | WETH, wstETH, cbETH, rETH, weETH, osETH, ETHx | WETH, wstETH, cbETH, rETH, PYUSD, weETH, osETH, ETHx |
+| eMode.collateralBitmap | WETH, wstETH, cbETH, rETH, weETH, osETH, ETHx | WETH, wstETH, cbETH, rETH, PYUSD, weETH, osETH, ETHx |
+
+
+## Raw diff
+
+```json
+{
+  "eModes": {
+    "1": {
+      "borrowableBitmap": {
+        "from": "2952790659",
+        "to": "3087008387"
+      },
+      "collateralBitmap": {
+        "from": "2952790659",
+        "to": "3087008387"
+      }
+    }
+  },
+  "reserves": {
+    "0x6c3ea9036406852006290770BEdFcAbA0e23A0e8": {
+      "borrowCap": {
+        "from": 48000000,
+        "to": 15000000
+      },
+      "liquidationBonus": {
+        "from": 0,
+        "to": 10750
+      },
+      "liquidationProtocolFee": {
+        "from": 0,
+        "to": 1000
+      },
+      "liquidationThreshold": {
+        "from": 0,
+        "to": 7800
+      },
+      "ltv": {
+        "from": 0,
+        "to": 7500
+      },
+      "usageAsCollateralEnabled": {
+        "from": false,
+        "to": true
+      }
+    }
+  }
+}
+```

--- a/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.sol
+++ b/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {AaveV3Ethereum, AaveV3EthereumAssets, AaveV3EthereumEModes} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
 import {AaveV3PayloadEthereum} from 'aave-helpers/src/v3-config-engine/AaveV3PayloadEthereum.sol';
 import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
 import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
@@ -60,24 +60,5 @@ contract AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_2024103
     });
 
     return collateralUpdate;
-  }
-
-  function assetsEModeUpdates()
-    public
-    pure
-    override
-    returns (IAaveV3ConfigEngine.AssetEModeUpdate[] memory)
-  {
-    IAaveV3ConfigEngine.AssetEModeUpdate[]
-      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](1);
-
-    assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
-      asset: AaveV3EthereumAssets.PYUSD_UNDERLYING,
-      eModeCategory: AaveV3EthereumEModes.ETH_CORRELATED,
-      borrowable: EngineFlags.ENABLED,
-      collateral: EngineFlags.ENABLED
-    });
-
-    return assetEModeUpdates;
   }
 }

--- a/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.sol
+++ b/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3Ethereum, AaveV3EthereumAssets, AaveV3EthereumEModes} from 'aave-address-book/AaveV3Ethereum.sol';
+import {AaveV3PayloadEthereum} from 'aave-helpers/src/v3-config-engine/AaveV3PayloadEthereum.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
+import {IEmissionManager} from 'aave-v3-origin/contracts/rewards/interfaces/IEmissionManager.sol';
+
+/**
+ * @title PYUSD Reserve Configuration Update & Incentive Campaign
+ * @author karpatkey_TokenLogic
+ * - Snapshot: https://snapshot.org/#/aave.eth/proposal/0xcd73f17361c7757cd94ec758b4d9f160b7cecefa7f4cb23b0b4ee49b5eb1b8b2
+ * - Discussion: https://governance.aave.com/t/arfc-pyusd-reserve-configuration-update-incentive-campaign/19573
+ */
+contract AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031 is
+  AaveV3PayloadEthereum
+{
+  address public constant ALC_SAFE = 0xA1c93D2687f7014Aaf588c764E3Ce80aF016229b;
+  address public constant ACI_TREASURY = 0xac140648435d03f784879cd789130F22Ef588Fcd;
+  uint256 public constant GHO_AMOUNT = 300_000 ether;
+
+  function _postExecute() internal override {
+    AaveV3Ethereum.COLLECTOR.approve(AaveV3EthereumAssets.GHO_UNDERLYING, ALC_SAFE, GHO_AMOUNT);
+
+    IEmissionManager(AaveV3Ethereum.EMISSION_MANAGER).setEmissionAdmin(
+      AaveV3EthereumAssets.PYUSD_A_TOKEN,
+      ACI_TREASURY
+    );
+  }
+
+  function capsUpdates() public pure override returns (IAaveV3ConfigEngine.CapsUpdate[] memory) {
+    IAaveV3ConfigEngine.CapsUpdate[] memory capsUpdate = new IAaveV3ConfigEngine.CapsUpdate[](1);
+
+    capsUpdate[0] = IAaveV3ConfigEngine.CapsUpdate({
+      asset: AaveV3EthereumAssets.PYUSD_UNDERLYING,
+      supplyCap: EngineFlags.KEEP_CURRENT,
+      borrowCap: 15_000_000
+    });
+
+    return capsUpdate;
+  }
+
+  function collateralsUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.CollateralUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.CollateralUpdate[]
+      memory collateralUpdate = new IAaveV3ConfigEngine.CollateralUpdate[](1);
+
+    collateralUpdate[0] = IAaveV3ConfigEngine.CollateralUpdate({
+      asset: AaveV3EthereumAssets.PYUSD_UNDERLYING,
+      ltv: 75_00,
+      liqThreshold: 78_00,
+      liqBonus: 7_50,
+      debtCeiling: EngineFlags.KEEP_CURRENT,
+      liqProtocolFee: 10_00
+    });
+
+    return collateralUpdate;
+  }
+
+  function assetsEModeUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.AssetEModeUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.AssetEModeUpdate[]
+      memory assetEModeUpdates = new IAaveV3ConfigEngine.AssetEModeUpdate[](1);
+
+    assetEModeUpdates[0] = IAaveV3ConfigEngine.AssetEModeUpdate({
+      asset: AaveV3EthereumAssets.PYUSD_UNDERLYING,
+      eModeCategory: AaveV3EthereumEModes.ETH_CORRELATED,
+      borrowable: EngineFlags.ENABLED,
+      collateral: EngineFlags.ENABLED
+    });
+
+    return assetEModeUpdates;
+  }
+}

--- a/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.t.sol
+++ b/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.t.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IERC20} from 'solidity-utils/contracts/oz-common/interfaces/IERC20.sol';
+import {AaveV3Ethereum, AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {IEmissionManager} from 'aave-v3-origin/contracts/rewards/interfaces/IEmissionManager.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031} from './AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.sol';
+import {GovV3Helpers} from 'aave-helpers/src/GovV3Helpers.sol';
+
+/**
+ * @dev Test for AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031
+ * command: FOUNDRY_PROFILE=mainnet forge test --match-path=src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.t.sol -vv
+ */
+contract AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031_Test is
+  ProtocolV3TestBase
+{
+  AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 21085967);
+    proposal = new AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031',
+      AaveV3Ethereum.POOL,
+      address(proposal)
+    );
+  }
+
+  function test_checkAllowanceAndEmissionAdmin() public {
+    uint256 allowanceBefore = IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).allowance(
+      address(AaveV3Ethereum.COLLECTOR),
+      proposal.ALC_SAFE()
+    );
+
+    GovV3Helpers.executePayload(vm, address(proposal));
+
+    uint256 allowanceAfter = IERC20(AaveV3EthereumAssets.GHO_UNDERLYING).allowance(
+      address(AaveV3Ethereum.COLLECTOR),
+      proposal.ALC_SAFE()
+    );
+
+    assertEq(allowanceAfter - allowanceBefore, proposal.GHO_AMOUNT());
+
+    address pyusdEmissionAdmin = IEmissionManager(AaveV3Ethereum.EMISSION_MANAGER).getEmissionAdmin(
+      AaveV3EthereumAssets.PYUSD_A_TOKEN
+    );
+    assertEq(pyusdEmissionAdmin, proposal.ACI_TREASURY());
+  }
+}

--- a/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/PYUSDReserveConfigurationUpdateIncentiveCampaign.md
+++ b/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/PYUSDReserveConfigurationUpdateIncentiveCampaign.md
@@ -1,0 +1,61 @@
+---
+title: "PYUSD Reserve Configuration Update & Incentive Campaign"
+author: "karpatkey_TokenLogic"
+discussions: "https://governance.aave.com/t/arfc-pyusd-reserve-configuration-update-incentive-campaign/19573"
+snapshot: "https://snapshot.org/#/aave.eth/proposal/0xcd73f17361c7757cd94ec758b4d9f160b7cecefa7f4cb23b0b4ee49b5eb1b8b2"
+---
+
+## Simple Summary
+
+This publication proposes amendments to the PYUSD Reserve in preparation for an upcoming incentive campaign.
+
+Additionally, a co-incentive campaign is to be implemented to improve the PYUSD and GHO liquidity.
+
+## Motivation
+
+Trident Digital with support from PayPal, presents the Aave DAO with an opportunity to promote the adoption of PYUSD on Aave Protocol and PYUSD/GHO liquidity on Balancer for an initial 6 month period.
+
+Eligible Aave Protocol users are expected to receive up to 4.00% APR in Liquidity Mining (LM) rewards made available by Trident Digital on behalf of PayPal. The PYUSD reserve on Aave v3 is to be adjusted to align with the objectives of the PYUSD incentive campaign. Further details can be found on the governance forum.
+
+### PYUSD/GHO Liquidity
+
+As part of the PYUSD growth iniative, a 8M PYUSD/GHO Elliptic Liquidity Pool (ECLP) with an asymmetric concentrated liquidity profile will be used on Balancer.
+
+The pool will be funded and supported for an initial 6 month period with an additional 300k GHO made available to the ALC.
+
+## Specification
+
+The following PYUSD Reserve parameters are to be updated:
+
+| Parameter                | PYUSD  |
+| ------------------------ | ------ |
+| Borrowable               | Yes    |
+| Collateral               | Yes    |
+| Borrow Cap               | 15M    |
+| LTV                      | 75.00% |
+| LT                       | 78.00% |
+| Liquidation Penalty      | 7.50%  |
+| Liquidation Protocol Fee | 10.00% |
+
+Create 300k GHO Allowance for the ALC SAFE.
+
+ALC SAFE: `0xA1c93D2687f7014Aaf588c764E3Ce80aF016229b`
+GHO: `0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f`
+
+Whilst not expected to be needed, in case aEthPYUSD Liquidity Mining rewards are to be distributed across Aave v3, the ACI is to be granted sufficient permission to do so.
+
+EMISSION_MANAGER.setEmissionAdmin(`aEthPYUSD`,`ACI Treasury`)
+
+aEthPYUSD: `0x0C0d01AbF3e6aDfcA0989eBbA9d6e85dD58EaB1E`
+ACI Treasury: `0xac140648435d03f784879cd789130F22Ef588Fcd`
+
+## References
+
+- Implementation: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.sol)
+- Tests: [AaveV3Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.t.sol)
+- [Snapshot](https://snapshot.org/#/aave.eth/proposal/0xcd73f17361c7757cd94ec758b4d9f160b7cecefa7f4cb23b0b4ee49b5eb1b8b2)
+- [Discussion](https://governance.aave.com/t/arfc-pyusd-reserve-configuration-update-incentive-campaign/19573)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.s.sol
+++ b/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.s.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+import {EthereumScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031} from './AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * deploy-command: make deploy-ledger contract=src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.s.sol:DeployEthereum chain=mainnet
+ * verify-command: FOUNDRY_PROFILE=mainnet npx catapulta-verify -b broadcast/PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.s.sol/1/run-latest.json
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](1);
+
+    // compose actions for validation
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
+    actionsEthereum[0] = GovV3Helpers.buildAction(
+      type(AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign_20241031).creationCode
+    );
+    payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovernanceV3Ethereum.VOTING_PORTAL_ETH_POL,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/PYUSDReserveConfigurationUpdateIncentiveCampaign.md'
+      )
+    );
+  }
+}

--- a/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/config.ts
+++ b/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/config.ts
@@ -1,0 +1,41 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV3Ethereum'],
+    title: 'PYUSD Reserve Configuration Update & Incentive Campaign',
+    shortName: 'PYUSDReserveConfigurationUpdateIncentiveCampaign',
+    date: '20241031',
+    author: 'karpatkey_TokenLogic',
+    discussion:
+      'https://governance.aave.com/t/arfc-pyusd-reserve-configuration-update-incentive-campaign/19573',
+    snapshot:
+      'https://snapshot.org/#/aave.eth/proposal/0xcd73f17361c7757cd94ec758b4d9f160b7cecefa7f4cb23b0b4ee49b5eb1b8b2',
+    votingNetwork: 'POLYGON',
+  },
+  poolOptions: {
+    AaveV3Ethereum: {
+      configs: {
+        CAPS_UPDATE: [{asset: 'PYUSD', supplyCap: '', borrowCap: '15000000'}],
+        COLLATERALS_UPDATE: [
+          {
+            asset: 'PYUSD',
+            ltv: '75',
+            liqThreshold: '78',
+            liqBonus: '7.5',
+            debtCeiling: '',
+            liqProtocolFee: '10',
+          },
+        ],
+        EMODES_ASSETS: [
+          {
+            asset: 'PYUSD',
+            eModeCategory: 'AaveV3EthereumEModes.ETH_CORRELATED',
+            collateral: 'ENABLED',
+            borrowable: 'ENABLED',
+          },
+        ],
+      },
+      cache: {blockNumber: 21085967},
+    },
+  },
+};

--- a/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/config.ts
+++ b/src/20241031_AaveV3Ethereum_PYUSDReserveConfigurationUpdateIncentiveCampaign/config.ts
@@ -26,14 +26,6 @@ export const config: ConfigFile = {
             liqProtocolFee: '10',
           },
         ],
-        EMODES_ASSETS: [
-          {
-            asset: 'PYUSD',
-            eModeCategory: 'AaveV3EthereumEModes.ETH_CORRELATED',
-            collateral: 'ENABLED',
-            borrowable: 'ENABLED',
-          },
-        ],
       },
       cache: {blockNumber: 21085967},
     },


### PR DESCRIPTION
This publication proposes amendments to the PYUSD Reserve in preparation for an upcoming incentive campaign.

Additionally, a co-incentive campaign is to be implemented to improve the PYUSD and GHO liquidity.

The following PYUSD Reserve parameters are to be updated:

| Parameter                | PYUSD  |
| ------------------------ | ------ |
| Borrowable               | Yes    |
| Collateral               | Yes    |
| Borrow Cap               | 15M    |
| LTV                      | 75.00% |
| LT                       | 78.00% |
| Liquidation Penalty      | 7.50%  |
| Liquidation Protocol Fee | 10.00% |

Create 300k GHO Allowance for the ALC SAFE.

ALC SAFE: `0xA1c93D2687f7014Aaf588c764E3Ce80aF016229b`
GHO: `0x40D16FC0246aD3160Ccc09B8D0D3A2cD28aE6C2f`

Whilst not expected to be needed, in case aEthPYUSD Liquidity Mining rewards are to be distributed across Aave v3, the ACI is to be granted sufficient permission to do so.

EMISSION_MANAGER.setEmissionAdmin(`aEthPYUSD`,`ACI Treasury`)

aEthPYUSD: `0x0C0d01AbF3e6aDfcA0989eBbA9d6e85dD58EaB1E`
ACI Treasury: `0xac140648435d03f784879cd789130F22Ef588Fcd`