### PR TITLE
Apply deprecation updates on Ethereum, Polygon and Avalanche v2 reserves

### DIFF
--- a/diffs/AaveV2Avalanche_AaveV2DeprecationUpdate_20250925_before_AaveV2Avalanche_AaveV2DeprecationUpdate_20250925_after.md
+++ b/diffs/AaveV2Avalanche_AaveV2DeprecationUpdate_20250925_before_AaveV2Avalanche_AaveV2DeprecationUpdate_20250925_after.md
@@ -1,0 +1,399 @@
+## Reserve changes
+
+### Reserve altered
+
+#### WETH.e ([0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB](https://snowtrace.io/address/0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB))
+
+| description | value before | value after |
+| --- | --- | --- |
+| reserveFactor | 80 % [8000] | 85 % [8500] |
+| interestRateStrategy | [0x6724e923E4bb58fCdF7CEe7A5E7bBb47b99C2647](https://snowtrace.io/address/0x6724e923E4bb58fCdF7CEe7A5E7bBb47b99C2647) | [0xD9Dee878Eb31303FD58D412cE79439400b340A22](https://snowtrace.io/address/0xD9Dee878Eb31303FD58D412cE79439400b340A22) |
+| optimalUsageRatio | 45 % | 25 % |
+| variableRateSlope1 | 7 % | 15 % |
+| variableRateSlope2 | 300 % | 40 % |
+| maxExcessUsageRatio | 55 % | 75 % |
+| baseVariableBorrowRate | 0 % | 5 % |
+| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=70000000000000000000000000&variableRateSlope2=3000000000000000000000000000&optimalUsageRatio=450000000000000000000000000&baseVariableBorrowRate=0&maxVariableBorrowRate=undefined) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=150000000000000000000000000&variableRateSlope2=400000000000000000000000000&optimalUsageRatio=250000000000000000000000000&baseVariableBorrowRate=50000000000000000000000000&maxVariableBorrowRate=undefined) |
+
+#### WBTC.e ([0x50b7545627a5162F82A992c33b87aDc75187B218](https://snowtrace.io/address/0x50b7545627a5162F82A992c33b87aDc75187B218))
+
+| description | value before | value after |
+| --- | --- | --- |
+| interestRateStrategy | [0x3dED180433c1cb0B0697eD2e85cE598414DaCE58](https://snowtrace.io/address/0x3dED180433c1cb0B0697eD2e85cE598414DaCE58) | [0x7abB575574e221eF52A571974EdeBA870Fc0bBd8](https://snowtrace.io/address/0x7abB575574e221eF52A571974EdeBA870Fc0bBd8) |
+| optimalUsageRatio | 45 % | 25 % |
+| variableRateSlope2 | 300 % | 40 % |
+| maxExcessUsageRatio | 55 % | 75 % |
+| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=0&variableRateSlope2=3000000000000000000000000000&optimalUsageRatio=450000000000000000000000000&baseVariableBorrowRate=200000000000000000000000000&maxVariableBorrowRate=undefined) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=0&variableRateSlope2=400000000000000000000000000&optimalUsageRatio=250000000000000000000000000&baseVariableBorrowRate=200000000000000000000000000&maxVariableBorrowRate=undefined) |
+
+#### USDC.e ([0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664](https://snowtrace.io/address/0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664))
+
+| description | value before | value after |
+| --- | --- | --- |
+| reserveFactor | 80 % [8000] | 85 % [8500] |
+| interestRateStrategy | [0x6b410D0d53Efc7d4cAF23b9df2F38558998A1716](https://snowtrace.io/address/0x6b410D0d53Efc7d4cAF23b9df2F38558998A1716) | [0x04932041605c7ab646E0ff209d94241cd4651598](https://snowtrace.io/address/0x04932041605c7ab646E0ff209d94241cd4651598) |
+| optimalUsageRatio | 80 % | 25 % |
+| variableRateSlope1 | 10 % | 0 % |
+| variableRateSlope2 | 75 % | 40 % |
+| maxExcessUsageRatio | 20 % | 75 % |
+| baseVariableBorrowRate | 0 % | 5 % |
+| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=100000000000000000000000000&variableRateSlope2=750000000000000000000000000&optimalUsageRatio=800000000000000000000000000&baseVariableBorrowRate=0&maxVariableBorrowRate=undefined) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=0&variableRateSlope2=400000000000000000000000000&optimalUsageRatio=250000000000000000000000000&baseVariableBorrowRate=50000000000000000000000000&maxVariableBorrowRate=undefined) |
+
+#### WAVAX ([0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7](https://snowtrace.io/address/0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7))
+
+| description | value before | value after |
+| --- | --- | --- |
+| reserveFactor | 80 % [8000] | 85 % [8500] |
+| interestRateStrategy | [0x6724e923E4bb58fCdF7CEe7A5E7bBb47b99C2647](https://snowtrace.io/address/0x6724e923E4bb58fCdF7CEe7A5E7bBb47b99C2647) | [0xD9Dee878Eb31303FD58D412cE79439400b340A22](https://snowtrace.io/address/0xD9Dee878Eb31303FD58D412cE79439400b340A22) |
+| optimalUsageRatio | 45 % | 25 % |
+| variableRateSlope1 | 7 % | 15 % |
+| variableRateSlope2 | 300 % | 40 % |
+| maxExcessUsageRatio | 55 % | 75 % |
+| baseVariableBorrowRate | 0 % | 5 % |
+| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=70000000000000000000000000&variableRateSlope2=3000000000000000000000000000&optimalUsageRatio=450000000000000000000000000&baseVariableBorrowRate=0&maxVariableBorrowRate=undefined) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=150000000000000000000000000&variableRateSlope2=400000000000000000000000000&optimalUsageRatio=250000000000000000000000000&baseVariableBorrowRate=50000000000000000000000000&maxVariableBorrowRate=undefined) |
+
+#### USDT.e ([0xc7198437980c041c805A1EDcbA50c1Ce5db95118](https://snowtrace.io/address/0xc7198437980c041c805A1EDcbA50c1Ce5db95118))
+
+| description | value before | value after |
+| --- | --- | --- |
+| reserveFactor | 80 % [8000] | 85 % [8500] |
+| interestRateStrategy | [0xd814D29bBd27b97d58255632C498c34b25DC72bD](https://snowtrace.io/address/0xd814D29bBd27b97d58255632C498c34b25DC72bD) | [0x09F9063Fa492d562f414514c596c7f3c01c14714](https://snowtrace.io/address/0x09F9063Fa492d562f414514c596c7f3c01c14714) |
+| optimalUsageRatio | 80 % | 45 % |
+| variableRateSlope1 | 9 % | 15 % |
+| variableRateSlope2 | 75 % | 40 % |
+| maxExcessUsageRatio | 20 % | 55 % |
+| baseVariableBorrowRate | 0 % | 5 % |
+| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=90000000000000000000000000&variableRateSlope2=750000000000000000000000000&optimalUsageRatio=800000000000000000000000000&baseVariableBorrowRate=0&maxVariableBorrowRate=undefined) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=150000000000000000000000000&variableRateSlope2=400000000000000000000000000&optimalUsageRatio=450000000000000000000000000&baseVariableBorrowRate=50000000000000000000000000&maxVariableBorrowRate=undefined) |
+
+#### DAI.e ([0xd586E7F844cEa2F87f50152665BCbc2C279D8d70](https://snowtrace.io/address/0xd586E7F844cEa2F87f50152665BCbc2C279D8d70))
+
+| description | value before | value after |
+| --- | --- | --- |
+| reserveFactor | 80 % [8000] | 85 % [8500] |
+| interestRateStrategy | [0xd814D29bBd27b97d58255632C498c34b25DC72bD](https://snowtrace.io/address/0xd814D29bBd27b97d58255632C498c34b25DC72bD) | [0x9A2362afe62D7cE7a69f2cE61aED6aB0aF109294](https://snowtrace.io/address/0x9A2362afe62D7cE7a69f2cE61aED6aB0aF109294) |
+| baseVariableBorrowRate | 0 % | 5 % |
+| variableRateSlope1 | 9 % | 15 % |
+| variableRateSlope2 | 75 % | 40 % |
+| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=90000000000000000000000000&variableRateSlope2=750000000000000000000000000&optimalUsageRatio=800000000000000000000000000&baseVariableBorrowRate=0&maxVariableBorrowRate=undefined) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=150000000000000000000000000&variableRateSlope2=400000000000000000000000000&optimalUsageRatio=800000000000000000000000000&baseVariableBorrowRate=50000000000000000000000000&maxVariableBorrowRate=undefined) |
+
+## Raw diff
+
+```json
+{
+  "reserves": {
+    "0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB": {
+      "interestRateStrategy": {
+        "from": "0x6724e923E4bb58fCdF7CEe7A5E7bBb47b99C2647",
+        "to": "0xD9Dee878Eb31303FD58D412cE79439400b340A22"
+      },
+      "reserveFactor": {
+        "from": 8000,
+        "to": 8500
+      }
+    },
+    "0x50b7545627a5162F82A992c33b87aDc75187B218": {
+      "interestRateStrategy": {
+        "from": "0x3dED180433c1cb0B0697eD2e85cE598414DaCE58",
+        "to": "0x7abB575574e221eF52A571974EdeBA870Fc0bBd8"
+      }
+    },
+    "0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664": {
+      "interestRateStrategy": {
+        "from": "0x6b410D0d53Efc7d4cAF23b9df2F38558998A1716",
+        "to": "0x04932041605c7ab646E0ff209d94241cd4651598"
+      },
+      "reserveFactor": {
+        "from": 8000,
+        "to": 8500
+      }
+    },
+    "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7": {
+      "interestRateStrategy": {
+        "from": "0x6724e923E4bb58fCdF7CEe7A5E7bBb47b99C2647",
+        "to": "0xD9Dee878Eb31303FD58D412cE79439400b340A22"
+      },
+      "reserveFactor": {
+        "from": 8000,
+        "to": 8500
+      }
+    },
+    "0xc7198437980c041c805A1EDcbA50c1Ce5db95118": {
+      "interestRateStrategy": {
+        "from": "0xd814D29bBd27b97d58255632C498c34b25DC72bD",
+        "to": "0x09F9063Fa492d562f414514c596c7f3c01c14714"
+      },
+      "reserveFactor": {
+        "from": 8000,
+        "to": 8500
+      }
+    },
+    "0xd586E7F844cEa2F87f50152665BCbc2C279D8d70": {
+      "interestRateStrategy": {
+        "from": "0xd814D29bBd27b97d58255632C498c34b25DC72bD",
+        "to": "0x9A2362afe62D7cE7a69f2cE61aED6aB0aF109294"
+      },
+      "reserveFactor": {
+        "from": 8000,
+        "to": 8500
+      }
+    }
+  },
+  "strategies": {
+    "0x49D5c2BdFfac6CE2BFdB6640F4F80f226bc10bAB": {
+      "address": {
+        "from": "0x6724e923E4bb58fCdF7CEe7A5E7bBb47b99C2647",
+        "to": "0xD9Dee878Eb31303FD58D412cE79439400b340A22"
+      },
+      "baseVariableBorrowRate": {
+        "from": "0",
+        "to": "50000000000000000000000000"
+      },
+      "maxExcessUsageRatio": {
+        "from": "550000000000000000000000000",
+        "to": "750000000000000000000000000"
+      },
+      "optimalUsageRatio": {
+        "from": "450000000000000000000000000",
+        "to": "250000000000000000000000000"
+      },
+      "variableRateSlope1": {
+        "from": "70000000000000000000000000",
+        "to": "150000000000000000000000000"
+      },
+      "variableRateSlope2": {
+        "from": "3000000000000000000000000000",
+        "to": "400000000000000000000000000"
+      }
+    },
+    "0x50b7545627a5162F82A992c33b87aDc75187B218": {
+      "address": {
+        "from": "0x3dED180433c1cb0B0697eD2e85cE598414DaCE58",
+        "to": "0x7abB575574e221eF52A571974EdeBA870Fc0bBd8"
+      },
+      "maxExcessUsageRatio": {
+        "from": "550000000000000000000000000",
+        "to": "750000000000000000000000000"
+      },
+      "optimalUsageRatio": {
+        "from": "450000000000000000000000000",
+        "to": "250000000000000000000000000"
+      },
+      "variableRateSlope2": {
+        "from": "3000000000000000000000000000",
+        "to": "400000000000000000000000000"
+      }
+    },
+    "0xA7D7079b0FEaD91F3e65f86E8915Cb59c1a4C664": {
+      "address": {
+        "from": "0x6b410D0d53Efc7d4cAF23b9df2F38558998A1716",
+        "to": "0x04932041605c7ab646E0ff209d94241cd4651598"
+      },
+      "baseVariableBorrowRate": {
+        "from": "0",
+        "to": "50000000000000000000000000"
+      },
+      "maxExcessUsageRatio": {
+        "from": "200000000000000000000000000",
+        "to": "750000000000000000000000000"
+      },
+      "optimalUsageRatio": {
+        "from": "800000000000000000000000000",
+        "to": "250000000000000000000000000"
+      },
+      "variableRateSlope1": {
+        "from": "100000000000000000000000000",
+        "to": "0"
+      },
+      "variableRateSlope2": {
+        "from": "750000000000000000000000000",
+        "to": "400000000000000000000000000"
+      }
+    },
+    "0xB31f66AA3C1e785363F0875A1B74E27b85FD66c7": {
+      "address": {
+        "from": "0x6724e923E4bb58fCdF7CEe7A5E7bBb47b99C2647",
+        "to": "0xD9Dee878Eb31303FD58D412cE79439400b340A22"
+      },
+      "baseVariableBorrowRate": {
+        "from": "0",
+        "to": "50000000000000000000000000"
+      },
+      "maxExcessUsageRatio": {
+        "from": "550000000000000000000000000",
+        "to": "750000000000000000000000000"
+      },
+      "optimalUsageRatio": {
+        "from": "450000000000000000000000000",
+        "to": "250000000000000000000000000"
+      },
+      "variableRateSlope1": {
+        "from": "70000000000000000000000000",
+        "to": "150000000000000000000000000"
+      },
+      "variableRateSlope2": {
+        "from": "3000000000000000000000000000",
+        "to": "400000000000000000000000000"
+      }
+    },
+    "0xc7198437980c041c805A1EDcbA50c1Ce5db95118": {
+      "address": {
+        "from": "0xd814D29bBd27b97d58255632C498c34b25DC72bD",
+        "to": "0x09F9063Fa492d562f414514c596c7f3c01c14714"
+      },
+      "baseVariableBorrowRate": {
+        "from": "0",
+        "to": "50000000000000000000000000"
+      },
+      "maxExcessUsageRatio": {
+        "from": "200000000000000000000000000",
+        "to": "550000000000000000000000000"
+      },
+      "optimalUsageRatio": {
+        "from": "800000000000000000000000000",
+        "to": "450000000000000000000000000"
+      },
+      "variableRateSlope1": {
+        "from": "90000000000000000000000000",
+        "to": "150000000000000000000000000"
+      },
+      "variableRateSlope2": {
+        "from": "750000000000000000000000000",
+        "to": "400000000000000000000000000"
+      }
+    },
+    "0xd586E7F844cEa2F87f50152665BCbc2C279D8d70": {
+      "address": {
+        "from": "0xd814D29bBd27b97d58255632C498c34b25DC72bD",
+        "to": "0x9A2362afe62D7cE7a69f2cE61aED6aB0aF109294"
+      },
+      "baseVariableBorrowRate": {
+        "from": "0",
+        "to": "50000000000000000000000000"
+      },
+      "variableRateSlope1": {
+        "from": "90000000000000000000000000",
+        "to": "150000000000000000000000000"
+      },
+      "variableRateSlope2": {
+        "from": "750000000000000000000000000",
+        "to": "400000000000000000000000000"
+      }
+    }
+  },
+  "raw": {
+    "0x1140cb7cafacc745771c2ea31e7b5c653c5d0b80": {
+      "label": "GovernanceV3Avalanche.PAYLOADS_CONTROLLER",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x767e32fd18349f6756b14c9960d71c7fab8d03be981e4c9c8d4aa06a28b66047": {
+          "previousValue": "0x0068d4713c000000000002000000000000000000000000000000000000000000",
+          "newValue": "0x0068d4713c000000000003000000000000000000000000000000000000000000"
+        },
+        "0x767e32fd18349f6756b14c9960d71c7fab8d03be981e4c9c8d4aa06a28b66048": {
+          "previousValue": "0x000000000000000000093a80000000000000690295bd00000000000000000000",
+          "newValue": "0x000000000000000000093a80000000000000690295bd00000000000068d4713d"
+        }
+      }
+    },
+    "0x4f01aed16d97e3ab5ab2b501154dc9bb0f1a5a2c": {
+      "label": "AaveV2Avalanche.POOL",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x1c436f4b938f845ee1b83ea962adc5e4cf97d5b57ac4ad0417f240d279307dc0": {
+          "previousValue": "0x000000000000000000000000000000000000000000001f40031229041e14189c",
+          "newValue": "0x000000000000000000000000000000000000000000002134031229041e14189c"
+        },
+        "0x1c436f4b938f845ee1b83ea962adc5e4cf97d5b57ac4ad0417f240d279307dc7": {
+          "previousValue": "0x000000000000000000000001d814d29bbd27b97d58255632c498c34b25dc72bd",
+          "newValue": "0x0000000000000000000000019a2362afe62d7ce7a69f2ce61aed6ab0af109294"
+        },
+        "0x39dff3183cb26c9dcd752d170fbb41505c23c8c6efcef5d6fbf04a41db655329": {
+          "previousValue": "0x000000000000000000000000000000000000000000001f40070629041e781d4c",
+          "newValue": "0x000000000000000000000000000000000000000000002134070629041e781d4c"
+        },
+        "0x39dff3183cb26c9dcd752d170fbb41505c23c8c6efcef5d6fbf04a41db655330": {
+          "previousValue": "0x0000000000000000000000036b410d0d53efc7d4caf23b9df2f38558998a1716",
+          "newValue": "0x00000000000000000000000304932041605c7ab646e0ff209d94241cd4651598"
+        },
+        "0x5f66982f143050cfca979720f32a697dc119a214707431fcd220ac0c0c3fb044": {
+          "previousValue": "0x000000000000000000000000000000000000000000001f400306000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000021340306000000000000"
+        },
+        "0x5f66982f143050cfca979720f32a697dc119a214707431fcd220ac0c0c3fb04b": {
+          "previousValue": "0x000000000000000000000002d814d29bbd27b97d58255632c498c34b25dc72bd",
+          "newValue": "0x00000000000000000000000209f9063fa492d562f414514c596c7f3c01c14714"
+        },
+        "0x80a6bd6ed3e5cca4d8041e8c1b3aba2518ab3610d9461271e76a3e14d6eaab9f": {
+          "previousValue": "0x000000000000000000000000000000000000000000001f4003122af819641388",
+          "newValue": "0x00000000000000000000000000000000000000000000213403122af819641388"
+        },
+        "0x80a6bd6ed3e5cca4d8041e8c1b3aba2518ab3610d9461271e76a3e14d6eaaba6": {
+          "previousValue": "0x0000000000000000000000066724e923e4bb58fcdf7cee7a5e7bbb47b99c2647",
+          "newValue": "0x000000000000000000000006d9dee878eb31303fd58d412ce79439400b340a22"
+        },
+        "0x8597339a395b4dd6e28bfeb5d53cc869f161f16c04f29a7e2b336429da7b3e6f": {
+          "previousValue": "0x000000000000000000000000000000000000000000001f4003122904203a1f40",
+          "newValue": "0x00000000000000000000000000000000000000000000213403122904203a1f40"
+        },
+        "0x8597339a395b4dd6e28bfeb5d53cc869f161f16c04f29a7e2b336429da7b3e76": {
+          "previousValue": "0x0000000000000000000000006724e923e4bb58fcdf7cee7a5e7bbb47b99c2647",
+          "newValue": "0x000000000000000000000000d9dee878eb31303fd58d412ce79439400b340a22"
+        },
+        "0xda7c10f4453fcde69e37a43a92c2608c261c2d87174e8c956ed3075ae0e388ad": {
+          "previousValue": "0x0000000000000000000000053ded180433c1cb0b0697ed2e85ce598414dace58",
+          "newValue": "0x0000000000000000000000057abb575574e221ef52a571974edeba870fc0bbd8"
+        }
+      }
+    },
+    "0x6e66e50870a93691c1b953788a3219e01fddedd7": {
+      "label": "AaveV2Avalanche.RATES_FACTORY",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x0000000000000000000000000000000000000000000000000000000000000002": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000007",
+          "newValue": "0x000000000000000000000000000000000000000000000000000000000000000c"
+        },
+        "0x079c868dc1613784520de37c7f7ad06ee2914bf06c733a613ba2edcc71b027ce": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000007abb575574e221ef52a571974edeba870fc0bbd8"
+        },
+        "0x1724cac0e8007bb79f55962739ed1389f2db4d88b3bba9b85e35a9009c96c427": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x000000000000000000000000d9dee878eb31303fd58d412ce79439400b340a22"
+        },
+        "0x19c404cbfbf1f03f7a79ca767c5526e700eeba4249d3620f59931a5226d078c4": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000009a2362afe62d7ce7a69f2ce61aed6ab0af109294"
+        },
+        "0x405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ad5": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x000000000000000000000000d9dee878eb31303fd58d412ce79439400b340a22"
+        },
+        "0x405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ad6": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000009a2362afe62d7ce7a69f2ce61aed6ab0af109294"
+        },
+        "0x405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ad7": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x00000000000000000000000009f9063fa492d562f414514c596c7f3c01c14714"
+        },
+        "0x405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ad8": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x00000000000000000000000004932041605c7ab646e0ff209d94241cd4651598"
+        },
+        "0x405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5ad9": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000007abb575574e221ef52a571974edeba870fc0bbd8"
+        },
+        "0xa9cd474e7a5c8ee6b73b34f1277f0703eae4218c50b32d202883644457069ac3": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x00000000000000000000000004932041605c7ab646e0ff209d94241cd4651598"
+        },
+        "0xbadee102a448999c225cf330a83902cf2e9558ac82c6509e87c2c801ac1b4a60": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x00000000000000000000000009f9063fa492d562f414514c596c7f3c01c14714"
+        }
+      }
+    }
+  }
+}
+```

--- a/diffs/AaveV2Ethereum_AaveV2DeprecationUpdate_20250925_before_AaveV2Ethereum_AaveV2DeprecationUpdate_20250925_after.md
+++ b/diffs/AaveV2Ethereum_AaveV2DeprecationUpdate_20250925_before_AaveV2Ethereum_AaveV2DeprecationUpdate_20250925_after.md
@@ -1,0 +1,338 @@
+## Reserve changes
+
+### Reserve altered
+
+#### WBTC ([0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599](https://etherscan.io/address/0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599))
+
+| description | value before | value after |
+| --- | --- | --- |
+| interestRateStrategy | [0x32f3A6134590fc2d9440663d35a2F0a6265F04c4](https://etherscan.io/address/0x32f3A6134590fc2d9440663d35a2F0a6265F04c4) | [0xdbcea77E2C4A0e6158a7555C249f28A8Da449178](https://etherscan.io/address/0xdbcea77E2C4A0e6158a7555C249f28A8Da449178) |
+| optimalUsageRatio | 65 % | 25 % |
+| variableRateSlope1 | 4 % | 0 % |
+| variableRateSlope2 | 300 % | 40 % |
+| maxExcessUsageRatio | 35 % | 75 % |
+| baseVariableBorrowRate | 0 % | 20 % |
+| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=40000000000000000000000000&variableRateSlope2=3000000000000000000000000000&optimalUsageRatio=650000000000000000000000000&baseVariableBorrowRate=0&maxVariableBorrowRate=undefined) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=0&variableRateSlope2=400000000000000000000000000&optimalUsageRatio=250000000000000000000000000&baseVariableBorrowRate=200000000000000000000000000&maxVariableBorrowRate=undefined) |
+
+#### DAI ([0x6B175474E89094C44Da98b954EedeAC495271d0F](https://etherscan.io/address/0x6B175474E89094C44Da98b954EedeAC495271d0F))
+
+| description | value before | value after |
+| --- | --- | --- |
+| reserveFactor | 70 % [7000] | 85 % [8500] |
+| interestRateStrategy | [0x231537BE2db93464B7A1D50AbF9390c0Da0FB65D](https://etherscan.io/address/0x231537BE2db93464B7A1D50AbF9390c0Da0FB65D) | [0x8A50d613d683c1c381aA027c4d922aE55Fd8A3B3](https://etherscan.io/address/0x8A50d613d683c1c381aA027c4d922aE55Fd8A3B3) |
+| optimalUsageRatio | 80 % | 50 % |
+| variableRateSlope2 | 60 % | 40 % |
+| maxExcessUsageRatio | 20 % | 50 % |
+| baseVariableBorrowRate | 0 % | 5 % |
+| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=125000000000000000000000000&variableRateSlope2=600000000000000000000000000&optimalUsageRatio=800000000000000000000000000&baseVariableBorrowRate=0&maxVariableBorrowRate=undefined) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=125000000000000000000000000&variableRateSlope2=400000000000000000000000000&optimalUsageRatio=500000000000000000000000000&baseVariableBorrowRate=50000000000000000000000000&maxVariableBorrowRate=undefined) |
+
+#### USDC ([0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48](https://etherscan.io/address/0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48))
+
+| description | value before | value after |
+| --- | --- | --- |
+| reserveFactor | 70 % [7000] | 85 % [8500] |
+| interestRateStrategy | [0x4e1494475048fa155F1D837B6bD51458bD170f48](https://etherscan.io/address/0x4e1494475048fa155F1D837B6bD51458bD170f48) | [0x54bE9DB9E111EBCe28c702825154f8c49e1eE93E](https://etherscan.io/address/0x54bE9DB9E111EBCe28c702825154f8c49e1eE93E) |
+| optimalUsageRatio | 90 % | 60 % |
+| variableRateSlope2 | 60 % | 40 % |
+| maxExcessUsageRatio | 10 % | 40 % |
+| baseVariableBorrowRate | 0 % | 5 % |
+| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=125000000000000000000000000&variableRateSlope2=600000000000000000000000000&optimalUsageRatio=900000000000000000000000000&baseVariableBorrowRate=0&maxVariableBorrowRate=undefined) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=125000000000000000000000000&variableRateSlope2=400000000000000000000000000&optimalUsageRatio=600000000000000000000000000&baseVariableBorrowRate=50000000000000000000000000&maxVariableBorrowRate=undefined) |
+
+#### WETH ([0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2](https://etherscan.io/address/0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2))
+
+| description | value before | value after |
+| --- | --- | --- |
+| interestRateStrategy | [0xb8975328Aa52c00B9Ec1e11e518C4900f2e6C62a](https://etherscan.io/address/0xb8975328Aa52c00B9Ec1e11e518C4900f2e6C62a) | [0x013cDe9e76Fd7Cab355b9f884ad8EE4Ccb781278](https://etherscan.io/address/0x013cDe9e76Fd7Cab355b9f884ad8EE4Ccb781278) |
+| optimalUsageRatio | 80 % | 25 % |
+| variableRateSlope1 | 3.8 % | 5 % |
+| variableRateSlope2 | 80 % | 40 % |
+| maxExcessUsageRatio | 20 % | 75 % |
+| baseVariableBorrowRate | 1 % | 5 % |
+| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=38000000000000000000000000&variableRateSlope2=800000000000000000000000000&optimalUsageRatio=800000000000000000000000000&baseVariableBorrowRate=10000000000000000000000000&maxVariableBorrowRate=undefined) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=50000000000000000000000000&variableRateSlope2=400000000000000000000000000&optimalUsageRatio=250000000000000000000000000&baseVariableBorrowRate=50000000000000000000000000&maxVariableBorrowRate=undefined) |
+
+#### USDT ([0xdAC17F958D2ee523a2206206994597C13D831ec7](https://etherscan.io/address/0xdAC17F958D2ee523a2206206994597C13D831ec7))
+
+| description | value before | value after |
+| --- | --- | --- |
+| reserveFactor | 70 % [7000] | 85 % [8500] |
+| interestRateStrategy | [0xe85dA2C9D406afe7A37F525b5CAbEDA42944dB6f](https://etherscan.io/address/0xe85dA2C9D406afe7A37F525b5CAbEDA42944dB6f) | [0x2D8A2d50D3158085180D32A9C0655b13bce81f22](https://etherscan.io/address/0x2D8A2d50D3158085180D32A9C0655b13bce81f22) |
+| optimalUsageRatio | 80 % | 40 % |
+| variableRateSlope2 | 60 % | 40 % |
+| maxExcessUsageRatio | 20 % | 60 % |
+| baseVariableBorrowRate | 0 % | 5 % |
+| interestRate | ![before](https://dash.onaave.com/api/static?variableRateSlope1=125000000000000000000000000&variableRateSlope2=600000000000000000000000000&optimalUsageRatio=800000000000000000000000000&baseVariableBorrowRate=0&maxVariableBorrowRate=undefined) | ![after](https://dash.onaave.com/api/static?variableRateSlope1=125000000000000000000000000&variableRateSlope2=400000000000000000000000000&optimalUsageRatio=400000000000000000000000000&baseVariableBorrowRate=50000000000000000000000000&maxVariableBorrowRate=undefined) |
+
+## Raw diff
+
+```json
+{
+  "reserves": {
+    "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599": {
+      "interestRateStrategy": {
+        "from": "0x32f3A6134590fc2d9440663d35a2F0a6265F04c4",
+        "to": "0xdbcea77E2C4A0e6158a7555C249f28A8Da449178"
+      }
+    },
+    "0x6B175474E89094C44Da98b954EedeAC495271d0F": {
+      "interestRateStrategy": {
+        "from": "0x231537BE2db93464B7A1D50AbF9390c0Da0FB65D",
+        "to": "0x8A50d613d683c1c381aA027c4d922aE55Fd8A3B3"
+      },
+      "reserveFactor": {
+        "from": 7000,
+        "to": 8500
+      }
+    },
+    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": {
+      "interestRateStrategy": {
+        "from": "0x4e1494475048fa155F1D837B6bD51458bD170f48",
+        "to": "0x54bE9DB9E111EBCe28c702825154f8c49e1eE93E"
+      },
+      "reserveFactor": {
+        "from": 7000,
+        "to": 8500
+      }
+    },
+    "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+      "interestRateStrategy": {
+        "from": "0xb8975328Aa52c00B9Ec1e11e518C4900f2e6C62a",
+        "to": "0x013cDe9e76Fd7Cab355b9f884ad8EE4Ccb781278"
+      }
+    },
+    "0xdAC17F958D2ee523a2206206994597C13D831ec7": {
+      "interestRateStrategy": {
+        "from": "0xe85dA2C9D406afe7A37F525b5CAbEDA42944dB6f",
+        "to": "0x2D8A2d50D3158085180D32A9C0655b13bce81f22"
+      },
+      "reserveFactor": {
+        "from": 7000,
+        "to": 8500
+      }
+    }
+  },
+  "strategies": {
+    "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599": {
+      "address": {
+        "from": "0x32f3A6134590fc2d9440663d35a2F0a6265F04c4",
+        "to": "0xdbcea77E2C4A0e6158a7555C249f28A8Da449178"
+      },
+      "baseVariableBorrowRate": {
+        "from": "0",
+        "to": "200000000000000000000000000"
+      },
+      "maxExcessUsageRatio": {
+        "from": "350000000000000000000000000",
+        "to": "750000000000000000000000000"
+      },
+      "optimalUsageRatio": {
+        "from": "650000000000000000000000000",
+        "to": "250000000000000000000000000"
+      },
+      "variableRateSlope1": {
+        "from": "40000000000000000000000000",
+        "to": "0"
+      },
+      "variableRateSlope2": {
+        "from": "3000000000000000000000000000",
+        "to": "400000000000000000000000000"
+      }
+    },
+    "0x6B175474E89094C44Da98b954EedeAC495271d0F": {
+      "address": {
+        "from": "0x231537BE2db93464B7A1D50AbF9390c0Da0FB65D",
+        "to": "0x8A50d613d683c1c381aA027c4d922aE55Fd8A3B3"
+      },
+      "baseVariableBorrowRate": {
+        "from": "0",
+        "to": "50000000000000000000000000"
+      },
+      "maxExcessUsageRatio": {
+        "from": "200000000000000000000000000",
+        "to": "500000000000000000000000000"
+      },
+      "optimalUsageRatio": {
+        "from": "800000000000000000000000000",
+        "to": "500000000000000000000000000"
+      },
+      "variableRateSlope2": {
+        "from": "600000000000000000000000000",
+        "to": "400000000000000000000000000"
+      }
+    },
+    "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48": {
+      "address": {
+        "from": "0x4e1494475048fa155F1D837B6bD51458bD170f48",
+        "to": "0x54bE9DB9E111EBCe28c702825154f8c49e1eE93E"
+      },
+      "baseVariableBorrowRate": {
+        "from": "0",
+        "to": "50000000000000000000000000"
+      },
+      "maxExcessUsageRatio": {
+        "from": "100000000000000000000000000",
+        "to": "400000000000000000000000000"
+      },
+      "optimalUsageRatio": {
+        "from": "900000000000000000000000000",
+        "to": "600000000000000000000000000"
+      },
+      "variableRateSlope2": {
+        "from": "600000000000000000000000000",
+        "to": "400000000000000000000000000"
+      }
+    },
+    "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2": {
+      "address": {
+        "from": "0xb8975328Aa52c00B9Ec1e11e518C4900f2e6C62a",
+        "to": "0x013cDe9e76Fd7Cab355b9f884ad8EE4Ccb781278"
+      },
+      "baseVariableBorrowRate": {
+        "from": "10000000000000000000000000",
+        "to": "50000000000000000000000000"
+      },
+      "maxExcessUsageRatio": {
+        "from": "200000000000000000000000000",
+        "to": "750000000000000000000000000"
+      },
+      "optimalUsageRatio": {
+        "from": "800000000000000000000000000",
+        "to": "250000000000000000000000000"
+      },
+      "variableRateSlope1": {
+        "from": "38000000000000000000000000",
+        "to": "50000000000000000000000000"
+      },
+      "variableRateSlope2": {
+        "from": "800000000000000000000000000",
+        "to": "400000000000000000000000000"
+      }
+    },
+    "0xdAC17F958D2ee523a2206206994597C13D831ec7": {
+      "address": {
+        "from": "0xe85dA2C9D406afe7A37F525b5CAbEDA42944dB6f",
+        "to": "0x2D8A2d50D3158085180D32A9C0655b13bce81f22"
+      },
+      "baseVariableBorrowRate": {
+        "from": "0",
+        "to": "50000000000000000000000000"
+      },
+      "maxExcessUsageRatio": {
+        "from": "200000000000000000000000000",
+        "to": "600000000000000000000000000"
+      },
+      "optimalUsageRatio": {
+        "from": "800000000000000000000000000",
+        "to": "400000000000000000000000000"
+      },
+      "variableRateSlope2": {
+        "from": "600000000000000000000000000",
+        "to": "400000000000000000000000000"
+      }
+    }
+  },
+  "raw": {
+    "0x7d2768de32b0b80b7a3454c06bdac94a69ddc7a9": {
+      "label": "AaveV2Ethereum.POOL",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x212aa9bd7b173642810e5e991e9e9ed2f6ac3087d28021b9f35fb9d1a8d1160e": {
+          "previousValue": "0x000000000000000000000000000000000000000000001b58011228a01e14189c",
+          "newValue": "0x000000000000000000000000000000000000000000002134011228a01e14189c"
+        },
+        "0x212aa9bd7b173642810e5e991e9e9ed2f6ac3087d28021b9f35fb9d1a8d11615": {
+          "previousValue": "0x000000000000000000000009231537be2db93464b7a1d50abf9390c0da0fb65d",
+          "newValue": "0x0000000000000000000000098a50d613d683c1c381aa027c4d922ae55fd8a3b3"
+        },
+        "0x4cb5a02f592bd29403ce60c982c7f5174b16842da4fff5cfd025d6836dc48d52": {
+          "previousValue": "0x000000000000000000000002b8975328aa52c00b9ec1e11e518c4900f2e6c62a",
+          "newValue": "0x000000000000000000000002013cde9e76fd7cab355b9f884ad8ee4ccb781278"
+        },
+        "0x53bbdf4cf4f70d2494b9e1c24700a6c1a17d11c747522a0d584f0f40229caaab": {
+          "previousValue": "0x000000000000000000000000000000000000000000001b58010628d2222e1d4c",
+          "newValue": "0x000000000000000000000000000000000000000000002134010628d2222e1d4c"
+        },
+        "0x53bbdf4cf4f70d2494b9e1c24700a6c1a17d11c747522a0d584f0f40229caab2": {
+          "previousValue": "0x0000000000000000000000134e1494475048fa155f1d837b6bd51458bd170f48",
+          "newValue": "0x00000000000000000000001354be9db9e111ebce28c702825154f8c49e1ee93e"
+        },
+        "0xa5ac31719d9f4564672a106339496685f6250ad08b6ee3bf8e1ddeb0c36d52d2": {
+          "previousValue": "0x000000000000000000000000000000000000000000001b580106000000000000",
+          "newValue": "0x0000000000000000000000000000000000000000000021340106000000000000"
+        },
+        "0xa5ac31719d9f4564672a106339496685f6250ad08b6ee3bf8e1ddeb0c36d52d9": {
+          "previousValue": "0x000000000000000000000000e85da2c9d406afe7a37f525b5cabeda42944db6f",
+          "newValue": "0x0000000000000000000000002d8a2d50d3158085180d32a9c0655b13bce81f22"
+        },
+        "0xe08aad639ffd10ccac329590adb88878e4ea69ff976a955eed6ae73f151b10d6": {
+          "previousValue": "0x00000000000000000000000132f3a6134590fc2d9440663d35a2f0a6265f04c4",
+          "newValue": "0x000000000000000000000001dbcea77e2c4a0e6158a7555c249f28a8da449178"
+        }
+      }
+    },
+    "0xbd37610bbb1ddc2a22797f7e3f531b59902b7ba7": {
+      "label": "AaveV2Ethereum.RATES_FACTORY",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0x0000000000000000000000000000000000000000000000000000000000000002": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000037",
+          "newValue": "0x000000000000000000000000000000000000000000000000000000000000003c"
+        },
+        "0x01a051109c848841bf4ef4afce2e0e49bf2a58db84abdeaebdd456b2ea754d1c": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x000000000000000000000000dbcea77e2c4a0e6158a7555c249f28a8da449178"
+        },
+        "0x405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5b05": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000002d8a2d50d3158085180d32a9c0655b13bce81f22"
+        },
+        "0x405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5b06": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x000000000000000000000000dbcea77e2c4a0e6158a7555c249f28a8da449178"
+        },
+        "0x405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5b07": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x000000000000000000000000013cde9e76fd7cab355b9f884ad8ee4ccb781278"
+        },
+        "0x405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5b08": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000008a50d613d683c1c381aa027c4d922ae55fd8a3b3"
+        },
+        "0x405787fa12a823e0f2b7631cc41b3ba8828b3321ca811111fa75cd3aa3bb5b09": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x00000000000000000000000054be9db9e111ebce28c702825154f8c49e1ee93e"
+        },
+        "0x6e3573de0612344937a71d9dd4b0646b7b317c62144cf11de573ba5f2b3951b1": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000002d8a2d50d3158085180d32a9c0655b13bce81f22"
+        },
+        "0xb4d6a5b6bdf1b9d00a4bd7aab062e0326af997e81335e5b947a0cbc32f57e966": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x0000000000000000000000008a50d613d683c1c381aa027c4d922ae55fd8a3b3"
+        },
+        "0xb86ff9b60874486dce6463f85f4dfe6c1cd97b179baf9be424e5ad3a1990b6d1": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x00000000000000000000000054be9db9e111ebce28c702825154f8c49e1ee93e"
+        },
+        "0xdf086b85f64b5dd97b52bb277deebeb57874f7b215c44b553280f9dcc3974957": {
+          "previousValue": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "newValue": "0x000000000000000000000000013cde9e76fd7cab355b9f884ad8ee4ccb781278"
+        }
+      }
+    },
+    "0xdabad81af85554e9ae636395611c58f7ec1aaec5": {
+      "label": "GovernanceV3Ethereum.PAYLOADS_CONTROLLER",
+      "balanceDiff": null,
+      "stateDiff": {
+        "0xd2e6ebac8330a1a1b0846b0b511eeb9510273e6698f84244b6c63e1b0339d6ac": {
+          "previousValue": "0x0068d46daa000000000002000000000000000000000000000000000000000000",
+          "newValue": "0x0068d46daa000000000003000000000000000000000000000000000000000000"
+        },
+        "0xd2e6ebac8330a1a1b0846b0b511eeb9510273e6698f84244b6c63e1b0339d6ad": {
+          "previousValue": "0x000000000000000000093a800000000000006902922b00000000000000000000",
+          "newValue": "0x000000000000000000093a800000000000006902922b00000000000068d46dab"
+        }
+      }
+    }
+  }
+}
+```

--- a/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Avalanche_AaveV2DeprecationUpdate_20250925.sol
+++ b/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Avalanche_AaveV2DeprecationUpdate_20250925.sol
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV2AvalancheAssets} from 'aave-address-book/AaveV2Avalanche.sol';
+import {AaveV2PayloadAvalanche} from 'aave-helpers/src/v2-config-engine/AaveV2PayloadAvalanche.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV2ConfigEngine} from 'aave-helpers/src/v2-config-engine/IAaveV2ConfigEngine.sol';
+import {IV2RateStrategyFactory} from 'aave-helpers/src/v2-config-engine/IV2RateStrategyFactory.sol';
+import {ILendingPoolConfigurator} from 'aave-address-book/AaveV2.sol';
+import {AaveV2Avalanche} from 'aave-address-book/AaveV2Avalanche.sol';
+
+/**
+ * @title Aave v2 Deprecation - Update
+ * @author @TokenLogic
+ * - Snapshot: https://snapshot.box/#/s:aavedao.eth/proposal/0x0c5427caf17d21b321a3b62362d085e580446b136b0eccf7f4dc377856025486
+ * - Discussion: https://governance.aave.com/t/arfc-aave-v2-deprecation-update/23008/2
+ */
+contract AaveV2Avalanche_AaveV2DeprecationUpdate_20250925 is AaveV2PayloadAvalanche {
+  function rateStrategiesUpdates()
+    public
+    pure
+    override
+    returns (IAaveV2ConfigEngine.RateStrategyUpdate[] memory)
+  {
+    IAaveV2ConfigEngine.RateStrategyUpdate[]
+      memory rateStrategies = new IAaveV2ConfigEngine.RateStrategyUpdate[](6);
+    rateStrategies[0] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2AvalancheAssets.WETHe_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(25_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(15_00),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[1] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2AvalancheAssets.DAIe_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(80_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(15_00),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[2] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2AvalancheAssets.USDTe_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(45_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(15_00),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[3] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2AvalancheAssets.USDCe_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(25_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(0),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[4] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2AvalancheAssets.WBTCe_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(25_00),
+        baseVariableBorrowRate: _bpsToRay(20_00),
+        variableRateSlope1: _bpsToRay(0),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[5] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2AvalancheAssets.WAVAX_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(25_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(15_00),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+
+    return rateStrategies;
+  }
+
+  function _postExecute() internal override {
+    ILendingPoolConfigurator poolConfigurator = ILendingPoolConfigurator(
+      AaveV2Avalanche.POOL_CONFIGURATOR
+    );
+
+    // wETH: 80% -> 85%
+    poolConfigurator.setReserveFactor(AaveV2AvalancheAssets.WETHe_UNDERLYING, 85_00);
+    // USDC.e: 80% -> 85%
+    poolConfigurator.setReserveFactor(AaveV2AvalancheAssets.USDCe_UNDERLYING, 85_00);
+    // AVAX: 80% -> 85%
+    poolConfigurator.setReserveFactor(AaveV2AvalancheAssets.WAVAX_UNDERLYING, 85_00);
+    // USDT.e: 80% -> 85%
+    poolConfigurator.setReserveFactor(AaveV2AvalancheAssets.USDTe_UNDERLYING, 85_00);
+    // DAI: 80% -> 85%
+    poolConfigurator.setReserveFactor(AaveV2AvalancheAssets.DAIe_UNDERLYING, 85_00);
+  }
+}

--- a/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Avalanche_AaveV2DeprecationUpdate_20250925.t.sol
+++ b/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Avalanche_AaveV2DeprecationUpdate_20250925.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV2Avalanche} from 'aave-address-book/AaveV2Avalanche.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV2TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV2TestBase.sol';
+import {AaveV2Avalanche_AaveV2DeprecationUpdate_20250925} from './AaveV2Avalanche_AaveV2DeprecationUpdate_20250925.sol';
+
+/**
+ * @dev Test for AaveV2Avalanche_AaveV2DeprecationUpdate_20250925
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Avalanche_AaveV2DeprecationUpdate_20250925.t.sol -vv
+ */
+contract AaveV2Avalanche_AaveV2DeprecationUpdate_20250925_Test is ProtocolV2TestBase {
+  AaveV2Avalanche_AaveV2DeprecationUpdate_20250925 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('avalanche'), 69241072);
+    proposal = new AaveV2Avalanche_AaveV2DeprecationUpdate_20250925();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV2Avalanche_AaveV2DeprecationUpdate_20250925',
+      AaveV2Avalanche.POOL,
+      address(proposal)
+    );
+  }
+}

--- a/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2DeprecationUpdate.md
+++ b/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2DeprecationUpdate.md
@@ -1,0 +1,107 @@
+---
+title: "Aave v2 Deprecation - Update"
+author: "@TokenLogic"
+discussions: "https://governance.aave.com/t/arfc-aave-v2-deprecation-update/23008/2"
+snapshot: "https://snapshot.box/#/s:aavedao.eth/proposal/0x0c5427caf17d21b321a3b62362d085e580446b136b0eccf7f4dc377856025486"
+---
+
+## Simple Summary
+
+This proposal presents the next round of parameter updates to be implemented as we work towards deprecating v2 instances of Aave Protocol across Polygon, Ethereum and Avalanche.
+
+## Motivation
+
+This proposal builds on previous efforts that froze both Polygon v2 and Avalanche v2, supporting the deprecation of Aave v2 and ensuring a smooth, controlled, and secure transition to Aave v3.
+
+The proposed changes are designed to increase borrowing costs through adjustments to the interest rate curve parameters, creating stronger incentives for users to migrate to Aave v3. Where practical, a standardized approach of reducing the Uoptimal parameter has been applied, alongside adjustments to the Base and Slope1 parameters to raise borrow rates. At the same time, the Slope2 parameter has been reduced to avoid excessive borrowing costs at near-full utilization. Overall, these changes raise borrow rates without exposing users to extreme costs.
+
+The updated Uoptimal parameter now exceeds current reserve utilization levels and is expected to be progressively lowered toward a 25% target.
+
+For commonly borrowed assets, the Base parameter is increased to 5%, with further increases planned as reserve liquidity decreases. This gradual adjustment ensures a minimum borrow rate is always maintained.
+
+Additionally, the Reserve Factor is increased to 85%, resulting in lower deposit rates that discourage idle capital remaining in v2.
+
+These changes represent a coordinated effort among several service providers to align incentives and ensure the long-term health of the Aave ecosystem.
+
+## Specification
+
+### Ethereum v2
+
+RF / Base / Uoptimal
+
+| Asset | RF Current | RF Proposed | Base Current | Base Proposed | Uoptimal Current | Uoptimal Proposed |
+| ----- | ---------- | ----------- | ------------ | ------------- | ---------------- | ----------------- |
+| wETH  | 85.00%     | 85.00%      | 0.00%        | 5.00%         | 80.00%           | 25.00%            |
+| wBTC  | 90.00%     | 90.00%      | 0.00%        | 20.00%        | 65.00%           | 25.00%            |
+| USDC  | 70.00%     | 85.00%      | 0.00%        | 5.00%         | 90.00%           | 60.00%            |
+| USDT  | 70.00%     | 85.00%      | 0.00%        | 5.00%         | 80.00%           | 40.00%            |
+| DAI   | 70.00%     | 85.00%      | 0.00%        | 5.00%         | 80.00%           | 50.00%            |
+
+Slopes
+
+| Asset | Slope1 Current | Slope1 Proposed | Slope2 Current | Slope2 Proposed |
+| ----- | -------------- | --------------- | -------------- | --------------- |
+| wETH  | 3.80%          | 5.00%           | 80.00%         | 40.00%          |
+| wBTC  | 0.00%          | 0.00%           | 300.00%        | 40.00%          |
+| USDC  | 12.50%         | 12.50%          | 60.00%         | 40.00%          |
+| USDT  | 12.50%         | 12.50%          | 60.00%         | 40.00%          |
+| DAI   | 12.50%         | 12.50%          | 60.00%         | 40.00%          |
+
+### Polygon v2
+
+RF / Base / Uoptimal
+
+| Asset  | RF Current | RF Proposed | Base Current | Base Proposed | Uoptimal Current | Uoptimal Proposed |
+| ------ | ---------- | ----------- | ------------ | ------------- | ---------------- | ----------------- |
+| wETH   | 99.99%     | 99.99%      | 0.00%        | 5.00%         | 40.00%           | 25.00%            |
+| wBTC   | 99.99%     | 99.99%      | 0.00%        | 20.00%        | 37.00%           | 25.00%            |
+| USDC.e | 99.99%     | 99.99%      | 0.00%        | 5.00%         | 77.00%           | 65.00%            |
+| DAI    | 99.99%     | 99.99%      | 0.00%        | 5.00%         | 71.00%           | 45.00%            |
+| USDT   | 99.99%     | 99.99%      | 0.00%        | 5.00%         | 52.00%           | 35.00%            |
+| POL    | 99.99%     | 99.99%      | 0.00%        | 5.00%         | 48.00%           | 25.00%            |
+
+Slopes
+
+| Asset  | Slope1 Current | Slope1 Proposed | Slope2 Current | Slope2 Proposed |
+| ------ | -------------- | --------------- | -------------- | --------------- |
+| wETH   | 10.00%         | 15.00%          | 134.00%        | 40.00%          |
+| wBTC   | 0.00%          | 0.00%           | 134.00%        | 40.00%          |
+| USDC.e | 15.00%         | 15.00%          | 134.00%        | 40.00%          |
+| DAI    | 15.00%         | 15.00%          | 134.00%        | 40.00%          |
+| USDT   | 15.00%         | 15.00%          | 134.00%        | 40.00%          |
+| POL    | 12.00%         | 15.00%          | 134.00%        | 40.00%          |
+
+### Avalanche v2
+
+RF / Base / Uoptimal
+
+| Asset  | RF Current | RF Proposed | Base Current | Base Proposed | Uoptimal Current | Uoptimal Proposed |
+| ------ | ---------- | ----------- | ------------ | ------------- | ---------------- | ----------------- |
+| wBTC.e | 99.99%     | 99.99%      | 20.00%       | 20.00%        | 45.00%           | 25.00%            |
+| wETH   | 80.00%     | 85.00%      | 0.00%        | 5.00%         | 45.00%           | 25.00%            |
+| USDC.e | 80.00%     | 85.00%      | 0.00%        | 5.00%         | 80.00%           | 25.00%            |
+| AVAX   | 80.00%     | 85.00%      | 0.00%        | 5.00%         | 45.00%           | 25.00%            |
+| USDT.e | 80.00%     | 85.00%      | 0.00%        | 5.00%         | 80.00%           | 45.00%            |
+| DAI    | 80.00%     | 85.00%      | 0.00%        | 5.00%         | 80.00%           | 80.00%            |
+
+Slopes
+
+| Asset  | Slope1 Current | Slope1 Proposed | Slope2 Current | Slope2 Proposed |
+| ------ | -------------- | --------------- | -------------- | --------------- |
+| wBTC.e | 0.00%          | 0.00%           | 300.00%        | 40.00%          |
+| wETH   | 10.00%         | 15.00%          | 300.00%        | 40.00%          |
+| USDC.e | 0.00%          | 0.00%           | 75.00%         | 40.00%          |
+| AVAX   | 5.00%          | 15.00%          | 300.00%        | 40.00%          |
+| USDT.e | 9.00%          | 15.00%          | 75.00%         | 40.00%          |
+| DAI    | 9.00%          | 15.00%          | 75.00%         | 40.00%          |
+
+## References
+
+- Implementation: [AaveV2Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Ethereum_AaveV2DeprecationUpdate_20250925.sol), [AaveV2Polygon](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Polygon_AaveV2DeprecationUpdate_20250925.sol), [AaveV2Avalanche](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Avalanche_AaveV2DeprecationUpdate_20250925.sol)
+- Tests: [AaveV2Ethereum](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Ethereum_AaveV2DeprecationUpdate_20250925.t.sol), [AaveV2Polygon](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Polygon_AaveV2DeprecationUpdate_20250925.t.sol), [AaveV2Avalanche](https://github.com/bgd-labs/aave-proposals-v3/blob/main/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Avalanche_AaveV2DeprecationUpdate_20250925.t.sol)
+- [Snapshot](https://snapshot.box/#/s:aavedao.eth/proposal/0x0c5427caf17d21b321a3b62362d085e580446b136b0eccf7f4dc377856025486)
+- [Discussion](https://governance.aave.com/t/arfc-aave-v2-deprecation-update/23008/2)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2DeprecationUpdate_20250925.s.sol
+++ b/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2DeprecationUpdate_20250925.s.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+
+import {EthereumScript, PolygonScript, AvalancheScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV2Ethereum_AaveV2DeprecationUpdate_20250925} from './AaveV2Ethereum_AaveV2DeprecationUpdate_20250925.sol';
+import {AaveV2Polygon_AaveV2DeprecationUpdate_20250925} from './AaveV2Polygon_AaveV2DeprecationUpdate_20250925.sol';
+import {AaveV2Avalanche_AaveV2DeprecationUpdate_20250925} from './AaveV2Avalanche_AaveV2DeprecationUpdate_20250925.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * deploy-command: make deploy-ledger contract=src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2DeprecationUpdate_20250925.s.sol:DeployEthereum chain=mainnet
+ * verify-command: FOUNDRY_PROFILE=deploy npx catapulta-verify -b broadcast/AaveV2DeprecationUpdate_20250925.s.sol/1/run-latest.json
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV2Ethereum_AaveV2DeprecationUpdate_20250925).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Deploy Polygon
+ * deploy-command: make deploy-ledger contract=src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2DeprecationUpdate_20250925.s.sol:DeployPolygon chain=polygon
+ * verify-command: FOUNDRY_PROFILE=deploy npx catapulta-verify -b broadcast/AaveV2DeprecationUpdate_20250925.s.sol/137/run-latest.json
+ */
+contract DeployPolygon is PolygonScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV2Polygon_AaveV2DeprecationUpdate_20250925).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Deploy Avalanche
+ * deploy-command: make deploy-ledger contract=src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2DeprecationUpdate_20250925.s.sol:DeployAvalanche chain=avalanche
+ * verify-command: FOUNDRY_PROFILE=deploy npx catapulta-verify -b broadcast/AaveV2DeprecationUpdate_20250925.s.sol/43114/run-latest.json
+ */
+contract DeployAvalanche is AvalancheScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV2Avalanche_AaveV2DeprecationUpdate_20250925).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2DeprecationUpdate_20250925.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](3);
+
+    // compose actions for validation
+    {
+      IPayloadsControllerCore.ExecutionAction[]
+        memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
+      actionsEthereum[0] = GovV3Helpers.buildAction(
+        type(AaveV2Ethereum_AaveV2DeprecationUpdate_20250925).creationCode
+      );
+      payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+    }
+
+    {
+      IPayloadsControllerCore.ExecutionAction[]
+        memory actionsPolygon = new IPayloadsControllerCore.ExecutionAction[](1);
+      actionsPolygon[0] = GovV3Helpers.buildAction(
+        type(AaveV2Polygon_AaveV2DeprecationUpdate_20250925).creationCode
+      );
+      payloads[1] = GovV3Helpers.buildPolygonPayload(vm, actionsPolygon);
+    }
+
+    {
+      IPayloadsControllerCore.ExecutionAction[]
+        memory actionsAvalanche = new IPayloadsControllerCore.ExecutionAction[](1);
+      actionsAvalanche[0] = GovV3Helpers.buildAction(
+        type(AaveV2Avalanche_AaveV2DeprecationUpdate_20250925).creationCode
+      );
+      payloads[2] = GovV3Helpers.buildAvalanchePayload(vm, actionsAvalanche);
+    }
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovernanceV3Ethereum.VOTING_PORTAL_ETH_POL,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2DeprecationUpdate.md'
+      )
+    );
+  }
+}

--- a/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Ethereum_AaveV2DeprecationUpdate_20250925.sol
+++ b/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Ethereum_AaveV2DeprecationUpdate_20250925.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV2EthereumAssets} from 'aave-address-book/AaveV2Ethereum.sol';
+import {AaveV2PayloadEthereum} from 'aave-helpers/src/v2-config-engine/AaveV2PayloadEthereum.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV2ConfigEngine} from 'aave-helpers/src/v2-config-engine/IAaveV2ConfigEngine.sol';
+import {IV2RateStrategyFactory} from 'aave-helpers/src/v2-config-engine/IV2RateStrategyFactory.sol';
+import {ILendingPoolConfigurator} from 'aave-address-book/AaveV2.sol';
+import {AaveV2Ethereum} from 'aave-address-book/AaveV2Ethereum.sol';
+
+/**
+ * @title Aave v2 Deprecation - Update
+ * @author @TokenLogic
+ * - Snapshot: https://snapshot.box/#/s:aavedao.eth/proposal/0x0c5427caf17d21b321a3b62362d085e580446b136b0eccf7f4dc377856025486
+ * - Discussion: https://governance.aave.com/t/arfc-aave-v2-deprecation-update/23008/2
+ */
+contract AaveV2Ethereum_AaveV2DeprecationUpdate_20250925 is AaveV2PayloadEthereum {
+  function rateStrategiesUpdates()
+    public
+    pure
+    override
+    returns (IAaveV2ConfigEngine.RateStrategyUpdate[] memory)
+  {
+    IAaveV2ConfigEngine.RateStrategyUpdate[]
+      memory rateStrategies = new IAaveV2ConfigEngine.RateStrategyUpdate[](5);
+    rateStrategies[0] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2EthereumAssets.USDT_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(40_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(12_50),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[1] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2EthereumAssets.WBTC_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(25_00),
+        baseVariableBorrowRate: _bpsToRay(20_00),
+        variableRateSlope1: _bpsToRay(0),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[2] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2EthereumAssets.WETH_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(25_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(5_00),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[3] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2EthereumAssets.DAI_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(50_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(12_50),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[4] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2EthereumAssets.USDC_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(60_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(12_50),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+
+    return rateStrategies;
+  }
+
+  function _postExecute() internal override {
+    ILendingPoolConfigurator poolConfigurator = ILendingPoolConfigurator(
+      AaveV2Ethereum.POOL_CONFIGURATOR
+    );
+
+    // USDC: 70% -> 85%
+    poolConfigurator.setReserveFactor(AaveV2EthereumAssets.USDC_UNDERLYING, 85_00);
+    // USDT: 70% -> 85%
+    poolConfigurator.setReserveFactor(AaveV2EthereumAssets.USDT_UNDERLYING, 85_00);
+    // DAI: 70% -> 85%
+    poolConfigurator.setReserveFactor(AaveV2EthereumAssets.DAI_UNDERLYING, 85_00);
+  }
+}

--- a/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Ethereum_AaveV2DeprecationUpdate_20250925.t.sol
+++ b/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Ethereum_AaveV2DeprecationUpdate_20250925.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV2Ethereum} from 'aave-address-book/AaveV2Ethereum.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV2TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV2TestBase.sol';
+import {AaveV2Ethereum_AaveV2DeprecationUpdate_20250925} from './AaveV2Ethereum_AaveV2DeprecationUpdate_20250925.sol';
+
+/**
+ * @dev Test for AaveV2Ethereum_AaveV2DeprecationUpdate_20250925
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Ethereum_AaveV2DeprecationUpdate_20250925.t.sol -vv
+ */
+contract AaveV2Ethereum_AaveV2DeprecationUpdate_20250925_Test is ProtocolV2TestBase {
+  AaveV2Ethereum_AaveV2DeprecationUpdate_20250925 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 23435818);
+    proposal = new AaveV2Ethereum_AaveV2DeprecationUpdate_20250925();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV2Ethereum_AaveV2DeprecationUpdate_20250925',
+      AaveV2Ethereum.POOL,
+      address(proposal)
+    );
+  }
+}

--- a/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Polygon_AaveV2DeprecationUpdate_20250925.sol
+++ b/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Polygon_AaveV2DeprecationUpdate_20250925.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV2PolygonAssets} from 'aave-address-book/AaveV2Polygon.sol';
+import {AaveV2PayloadPolygon} from 'aave-helpers/src/v2-config-engine/AaveV2PayloadPolygon.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV2ConfigEngine} from 'aave-helpers/src/v2-config-engine/IAaveV2ConfigEngine.sol';
+import {IV2RateStrategyFactory} from 'aave-helpers/src/v2-config-engine/IV2RateStrategyFactory.sol';
+
+/**
+ * @title Aave v2 Deprecation - Update
+ * @author @TokenLogic
+ * - Snapshot: https://snapshot.box/#/s:aavedao.eth/proposal/0x0c5427caf17d21b321a3b62362d085e580446b136b0eccf7f4dc377856025486
+ * - Discussion: https://governance.aave.com/t/arfc-aave-v2-deprecation-update/23008/2
+ */
+contract AaveV2Polygon_AaveV2DeprecationUpdate_20250925 is AaveV2PayloadPolygon {
+  function rateStrategiesUpdates()
+    public
+    pure
+    override
+    returns (IAaveV2ConfigEngine.RateStrategyUpdate[] memory)
+  {
+    IAaveV2ConfigEngine.RateStrategyUpdate[]
+      memory rateStrategies = new IAaveV2ConfigEngine.RateStrategyUpdate[](6);
+    rateStrategies[0] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2PolygonAssets.DAI_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(45_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(15_00),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[1] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2PolygonAssets.USDC_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(65_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(15_00),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[2] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2PolygonAssets.USDT0_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(35_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(15_00),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[3] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2PolygonAssets.WBTC_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(25_00),
+        baseVariableBorrowRate: _bpsToRay(20_00),
+        variableRateSlope1: _bpsToRay(0),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[4] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2PolygonAssets.WETH_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(25_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(15_00),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+    rateStrategies[5] = IAaveV2ConfigEngine.RateStrategyUpdate({
+      asset: AaveV2PolygonAssets.WPOL_UNDERLYING,
+      params: IV2RateStrategyFactory.RateStrategyParams({
+        optimalUtilizationRate: _bpsToRay(25_00),
+        baseVariableBorrowRate: _bpsToRay(5_00),
+        variableRateSlope1: _bpsToRay(15_00),
+        variableRateSlope2: _bpsToRay(40_00),
+        stableRateSlope1: EngineFlags.KEEP_CURRENT,
+        stableRateSlope2: EngineFlags.KEEP_CURRENT
+      })
+    });
+
+    return rateStrategies;
+  }
+}

--- a/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Polygon_AaveV2DeprecationUpdate_20250925.t.sol
+++ b/src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Polygon_AaveV2DeprecationUpdate_20250925.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV2Polygon} from 'aave-address-book/AaveV2Polygon.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV2TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV2TestBase.sol';
+import {AaveV2Polygon_AaveV2DeprecationUpdate_20250925} from './AaveV2Polygon_AaveV2DeprecationUpdate_20250925.sol';
+
+/**
+ * @dev Test for AaveV2Polygon_AaveV2DeprecationUpdate_20250925
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20250925_Multi_AaveV2DeprecationUpdate/AaveV2Polygon_AaveV2DeprecationUpdate_20250925.t.sol -vv
+ */
+contract AaveV2Polygon_AaveV2DeprecationUpdate_20250925_Test is ProtocolV2TestBase {
+  AaveV2Polygon_AaveV2DeprecationUpdate_20250925 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('polygon'), 76860330);
+    proposal = new AaveV2Polygon_AaveV2DeprecationUpdate_20250925();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV2Polygon_AaveV2DeprecationUpdate_20250925',
+      AaveV2Polygon.POOL,
+      address(proposal)
+    );
+  }
+}

--- a/src/20250925_Multi_AaveV2DeprecationUpdate/config.ts
+++ b/src/20250925_Multi_AaveV2DeprecationUpdate/config.ts
@@ -1,0 +1,224 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    pools: ['AaveV2Ethereum', 'AaveV2Polygon', 'AaveV2Avalanche'],
+    title: 'Aave v2 Deprecation - Update',
+    shortName: 'AaveV2DeprecationUpdate',
+    date: '20250925',
+    author: '@TokenLogic',
+    discussion: 'https://governance.aave.com/t/arfc-aave-v2-deprecation-update/23008/2',
+    snapshot:
+      'https://snapshot.box/#/s:aavedao.eth/proposal/0x0c5427caf17d21b321a3b62362d085e580446b136b0eccf7f4dc377856025486',
+    votingNetwork: 'POLYGON',
+  },
+  poolOptions: {
+    AaveV2Ethereum: {
+      configs: {
+        RATE_UPDATE_V2: [
+          {
+            asset: 'USDT',
+            params: {
+              optimalUtilizationRate: '40',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '12.5',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'WBTC',
+            params: {
+              optimalUtilizationRate: '25',
+              baseVariableBorrowRate: '20',
+              variableRateSlope1: '0',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'WETH',
+            params: {
+              optimalUtilizationRate: '25',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '5',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'DAI',
+            params: {
+              optimalUtilizationRate: '50',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '12.5',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'USDC',
+            params: {
+              optimalUtilizationRate: '60',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '12.5',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+        ],
+      },
+      cache: {blockNumber: 23435818},
+    },
+    AaveV2Polygon: {
+      configs: {
+        RATE_UPDATE_V2: [
+          {
+            asset: 'DAI',
+            params: {
+              optimalUtilizationRate: '45',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '15',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'USDC',
+            params: {
+              optimalUtilizationRate: '65',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '15',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'USDT0',
+            params: {
+              optimalUtilizationRate: '',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '15',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'WBTC',
+            params: {
+              optimalUtilizationRate: '25',
+              baseVariableBorrowRate: '20',
+              variableRateSlope1: '0',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'WETH',
+            params: {
+              optimalUtilizationRate: '25',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '15',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'WPOL',
+            params: {
+              optimalUtilizationRate: '25',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '15',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+        ],
+      },
+      cache: {blockNumber: 76860330},
+    },
+    AaveV2Avalanche: {
+      configs: {
+        RATE_UPDATE_V2: [
+          {
+            asset: 'WETHe',
+            params: {
+              optimalUtilizationRate: '25',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '15',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'DAIe',
+            params: {
+              optimalUtilizationRate: '80',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '15',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'USDTe',
+            params: {
+              optimalUtilizationRate: '45',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '15',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'USDCe',
+            params: {
+              optimalUtilizationRate: '25',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '0',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'WBTCe',
+            params: {
+              optimalUtilizationRate: '25',
+              baseVariableBorrowRate: '20',
+              variableRateSlope1: '0',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+          {
+            asset: 'WAVAX',
+            params: {
+              optimalUtilizationRate: '25',
+              baseVariableBorrowRate: '5',
+              variableRateSlope1: '15',
+              variableRateSlope2: '40',
+              stableRateSlope1: '',
+              stableRateSlope2: '',
+            },
+          },
+        ],
+      },
+      cache: {blockNumber: 69241072},
+    },
+  },
+};


### PR DESCRIPTION
This PR implements the parameter updates specified in the [ARFC: Aave v2 Deprecation – Update](https://governance.aave.com/t/arfc-aave-v2-deprecation-update/23008/2) , applying changes on Ethereum, Polygon and Avalanche v2 reserves to incentivize migration to Aave v3.

Ethereum v2
- Updated rate strategies for wETH, wBTC, USDC, USDT, DAI.
- Increased Reserve Factor for USDC, USDT, DAI → 85% 

Polygon v2
- Updated rate strategies for wETH, wBTC, USDC.e, DAI, USDT, POL.
- Reserve Factors remain unchanged at 99.99%.

Avalanche v2
- Updated rate strategies for wBTC.e, wETH, USDC.e, AVAX, USDT.e, DAI.
- Increased Reserve Factor for wETH, USDC.e, AVAX, USDT.e, DAI → 85% 