### PR TITLE
Enables wstETH borrowing on Prime instance

### DIFF
--- a/diffs/AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720_before_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720_after.md
+++ b/diffs/AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720_before_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720_after.md
@@ -1,0 +1,61 @@
+## Reserve changes
+
+### Reserves altered
+
+#### wstETH ([0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0](https://etherscan.io/address/0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0))
+
+| description | value before | value after |
+| --- | --- | --- |
+| borrowingEnabled | :x: | :white_check_mark: |
+
+
+## Event logs
+
+#### 0x342631c6CeFC9cfbf97b2fe4aa242a236e1fd517 (AaveV3EthereumLido.POOL_CONFIGURATOR)
+
+| index | event |
+| --- | --- |
+| 0 | ReserveBorrowing(asset: 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0 (symbol: wstETH), enabled: true) |
+
+#### 0x5300A1a15135EA4dc7aD5a167152C01EFc9b192A (AaveV2Ethereum.POOL_ADMIN, AaveV2EthereumAMM.POOL_ADMIN, AaveV3Ethereum.ACL_ADMIN, AaveV3EthereumEtherFi.ACL_ADMIN, AaveV3EthereumHorizon.ACL_ADMIN, AaveV3EthereumLido.ACL_ADMIN, GovernanceV3Ethereum.EXECUTOR_LVL_1)
+
+| index | event |
+| --- | --- |
+| 1 | ExecutedAction(target: 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f, value: 0, signature: execute(), data: 0x, executionTime: 1784583407, withDelegatecall: true, resultData: 0x) |
+
+#### 0xdAbad81aF85554E9ae636395611C58F7eC1aAEc5 (GovernanceV3Ethereum.PAYLOADS_CONTROLLER)
+
+| index | event |
+| --- | --- |
+| 2 | PayloadExecuted(payloadId: 458) |
+
+## Raw storage changes
+
+### 0x4e033931ad43597d96d6bcc25c280717730b58b1 (AaveV3EthereumLido.POOL)
+
+| slot | previous value | new value |
+| --- | --- | --- |
+| 0xc9d7ec48cd0d839522455f78914adfeda8686316bb6819e0888e4bcd349e01b2 | 0x100000000000000000000103e800000f23000000000101f481122968206c2008 | 0x100000000000000000000103e800000f23000000000101f485122968206c2008 |
+
+### 0xdabad81af85554e9ae636395611c58f7ec1aaec5 (GovernanceV3Ethereum.PAYLOADS_CONTROLLER)
+
+| slot | previous value | new value |
+| --- | --- | --- |
+| 0xb5bd17e250aec4f1e352b02f19b359d072378fcc0c4054789dd519e60e58f0db | 0x006a5e94ee000000000002000000000000000000000000000000000000000000 | 0x006a5e94ee000000000003000000000000000000000000000000000000000000 |
+| 0xb5bd17e250aec4f1e352b02f19b359d072378fcc0c4054789dd519e60e58f0dc | 0x000000000000000000093a800000000000006a8cb96f00000000000000000000 | 0x000000000000000000093a800000000000006a8cb96f0000000000006a5e94ef |
+
+
+## Raw diff
+
+```json
+{
+  "reserves": {
+    "0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0": {
+      "borrowingEnabled": {
+        "from": false,
+        "to": true
+      }
+    }
+  }
+}
+```

--- a/src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720.sol
+++ b/src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumLidoAssets} from 'aave-address-book/AaveV3EthereumLido.sol';
+import {AaveV3PayloadEthereumLido} from 'aave-helpers/src/v3-config-engine/AaveV3PayloadEthereumLido.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
+
+/**
+ * @title Enable wstETH Borrowing on Prime
+ * @author @TokenLogic
+ * - Snapshot: Direct-to-AIP
+ * - Discussion: https://governance.aave.com/t/direct-to-aip-aave-v3-ltv-and-e-mode-update/25067
+ */
+contract AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720 is AaveV3PayloadEthereumLido {
+  function borrowsUpdates()
+    public
+    pure
+    override
+    returns (IAaveV3ConfigEngine.BorrowUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.BorrowUpdate[]
+      memory borrowUpdates = new IAaveV3ConfigEngine.BorrowUpdate[](1);
+
+    borrowUpdates[0] = IAaveV3ConfigEngine.BorrowUpdate({
+      asset: AaveV3EthereumLidoAssets.wstETH_UNDERLYING,
+      enabledToBorrow: EngineFlags.ENABLED,
+      flashloanable: EngineFlags.KEEP_CURRENT,
+      reserveFactor: EngineFlags.KEEP_CURRENT
+    });
+
+    return borrowUpdates;
+  }
+}

--- a/src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720.t.sol
+++ b/src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720.t.sol
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumLido, AaveV3EthereumLidoAssets} from 'aave-address-book/AaveV3EthereumLido.sol';
+import {EngineFlags} from 'aave-v3-origin/contracts/extensions/v3-config-engine/EngineFlags.sol';
+import {IAaveV3ConfigEngine} from 'aave-v3-origin/contracts/extensions/v3-config-engine/IAaveV3ConfigEngine.sol';
+
+import 'forge-std/Test.sol';
+import {ProtocolV3TestBase, ReserveConfig} from 'aave-helpers/src/ProtocolV3TestBase.sol';
+import {AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720} from './AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720.sol';
+
+/**
+ * @dev Test for AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720
+ * command: FOUNDRY_PROFILE=test forge test --match-path=src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720.t.sol -vv
+ */
+contract AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720_Test is ProtocolV3TestBase {
+  AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720 internal proposal;
+
+  function setUp() public {
+    vm.createSelectFork(vm.rpcUrl('mainnet'), 25576654);
+    proposal = new AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720();
+  }
+
+  /**
+   * @dev executes the generic test suite including e2e and config snapshots
+   * forge-config: default.isolate = true
+   */
+  function test_defaultProposalExecution() public {
+    defaultTest(
+      'AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720',
+      AaveV3EthereumLido.POOL,
+      address(proposal)
+    );
+  }
+
+  /**
+   * @dev checks whether reserve configurations changed or stayed unchanged as expected
+   */
+  function test_reserveConfigChanges() public {
+    address[] memory updatedAssets = new address[](1);
+    updatedAssets[0] = AaveV3EthereumLidoAssets.wstETH_UNDERLYING;
+    reserveConfigChangesTest(AaveV3EthereumLido.POOL, address(proposal), updatedAssets);
+  }
+
+  function _expectedBorrowChanges()
+    internal
+    pure
+    override
+    returns (IAaveV3ConfigEngine.BorrowUpdate[] memory)
+  {
+    IAaveV3ConfigEngine.BorrowUpdate[] memory borrowUpdates;
+    borrowUpdates = new IAaveV3ConfigEngine.BorrowUpdate[](1);
+
+    borrowUpdates[0] = IAaveV3ConfigEngine.BorrowUpdate({
+      asset: AaveV3EthereumLidoAssets.wstETH_UNDERLYING,
+      enabledToBorrow: EngineFlags.ENABLED,
+      flashloanable: EngineFlags.KEEP_CURRENT,
+      reserveFactor: EngineFlags.KEEP_CURRENT
+    });
+    return borrowUpdates;
+  }
+}

--- a/src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/EnableWstETHBorrowingOnPrime.md
+++ b/src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/EnableWstETHBorrowingOnPrime.md
@@ -1,0 +1,31 @@
+---
+title: "Enable wstETH Borrowing on Prime"
+author: "@TokenLogic"
+discussions: "https://governance.aave.com/t/direct-to-aip-aave-v3-ltv-and-e-mode-update/25067"
+---
+
+## Simple Summary
+
+This AIP re-enables wstETH borrowing on the Aave V3 Ethereum Prime instance, completing the borrow cap restoration approved in the [Aave V3 LTV and E-Mode Update](https://github.com/aave-dao/aave-proposals-v3/tree/main/src/20260707_Multi_AaveV3LTVAndEModeUpdate) proposal.
+
+## Motivation
+
+Following the oracle misconfiguration incident, wstETH borrowing on Prime was suspended: the borrow cap was reduced to 1 and the reserve's borrowing flag was disabled (previously enabled with a 280,000 cap). The Aave V3 LTV and E-Mode Update proposal restores the borrow cap to 18,000 as recommended by LlamaRisk, but does not re-enable the borrowing flag, so wstETH would remain non-borrowable after its execution. This AIP re-enables the flag.
+
+## Specification
+
+| Instance       | Asset  | Parameter       | Current  | New     |
+| -------------- | ------ | --------------- | -------- | ------- |
+| Ethereum Prime | wstETH | enabledToBorrow | DISABLED | ENABLED |
+
+The borrow cap is not modified by this payload; it is restored from 1 to 18,000 by the Aave V3 LTV and E-Mode Update AIP.
+
+## References
+
+- Implementation: [AaveV3EthereumLido](https://github.com/aave-dao/aave-proposals-v3/blob/main/src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720.sol)
+- Tests: [AaveV3EthereumLido](https://github.com/aave-dao/aave-proposals-v3/blob/main/src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720.t.sol)
+- [Discussion](https://governance.aave.com/t/direct-to-aip-aave-v3-ltv-and-e-mode-update/25067)
+
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/EnableWstETHBorrowingOnPrime_20260720.s.sol
+++ b/src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/EnableWstETHBorrowingOnPrime_20260720.s.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {GovV3Helpers, IPayloadsControllerCore, PayloadsControllerUtils} from 'aave-helpers/src/GovV3Helpers.sol';
+import {GovernanceV3Ethereum} from 'aave-address-book/GovernanceV3Ethereum.sol';
+
+import {EthereumScript} from 'solidity-utils/contracts/utils/ScriptUtils.sol';
+import {AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720} from './AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720.sol';
+
+/**
+ * @dev Deploy Ethereum
+ * deploy-command: make deploy-ledger contract=src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/EnableWstETHBorrowingOnPrime_20260720.s.sol:DeployEthereum chain=mainnet
+ * verify-command: FOUNDRY_PROFILE=deploy npx catapulta-verify -b broadcast/EnableWstETHBorrowingOnPrime_20260720.s.sol/1/run-latest.json
+ */
+contract DeployEthereum is EthereumScript {
+  function run() external broadcast {
+    // deploy payloads
+    address payload0 = GovV3Helpers.deployDeterministic(
+      type(AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720).creationCode
+    );
+
+    // compose action
+    IPayloadsControllerCore.ExecutionAction[]
+      memory actions = new IPayloadsControllerCore.ExecutionAction[](1);
+    actions[0] = GovV3Helpers.buildAction(payload0);
+
+    // register action at payloadsController
+    GovV3Helpers.createPayload(actions);
+  }
+}
+
+/**
+ * @dev Create Proposal
+ * command: make deploy-ledger contract=src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/EnableWstETHBorrowingOnPrime_20260720.s.sol:CreateProposal chain=mainnet
+ */
+contract CreateProposal is EthereumScript {
+  function run() external {
+    // create payloads
+    PayloadsControllerUtils.Payload[] memory payloads = new PayloadsControllerUtils.Payload[](1);
+
+    // compose actions for validation
+    {
+      IPayloadsControllerCore.ExecutionAction[]
+        memory actionsEthereum = new IPayloadsControllerCore.ExecutionAction[](1);
+      actionsEthereum[0] = GovV3Helpers.buildAction(
+        type(AaveV3EthereumLido_EnableWstETHBorrowingOnPrime_20260720).creationCode
+      );
+      payloads[0] = GovV3Helpers.buildMainnetPayload(vm, actionsEthereum);
+    }
+
+    // create proposal
+    vm.startBroadcast();
+    GovV3Helpers.createProposal(
+      vm,
+      payloads,
+      GovernanceV3Ethereum.VOTING_PORTAL_ETH_AVAX,
+      GovV3Helpers.ipfsHashFile(
+        vm,
+        'src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/EnableWstETHBorrowingOnPrime.md'
+      )
+    );
+  }
+}

--- a/src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/config.ts
+++ b/src/20260720_AaveV3EthereumLido_EnableWstETHBorrowingOnPrime/config.ts
@@ -1,0 +1,28 @@
+import {ConfigFile} from '../../generator/types';
+export const config: ConfigFile = {
+  rootOptions: {
+    markets: ['AaveV3EthereumLido'],
+    title: 'Enable wstETH Borrowing on Prime',
+    shortName: 'EnableWstETHBorrowingOnPrime',
+    date: '20260720',
+    author: '@TokenLogic',
+    discussion: 'https://governance.aave.com/t/direct-to-aip-aave-v3-ltv-and-e-mode-update/25067',
+    snapshot: 'Direct-to-AIP',
+    votingNetwork: 'AVALANCHE',
+  },
+  marketOptions: {
+    AaveV3EthereumLido: {
+      configs: {
+        BORROWS_UPDATE: [
+          {
+            enabledToBorrow: 'ENABLED',
+            flashloanable: 'KEEP_CURRENT',
+            reserveFactor: '',
+            asset: 'wstETH',
+          },
+        ],
+      },
+      cache: {blockNumber: 25576654},
+    },
+  },
+};


### PR DESCRIPTION
### Pre-review checklist:

- [x] I have run a spell check on the write-up and made sure no typos exist.
- [x] References to Snapshot/governance forum are correct on the AIP. If no snapshot exists, make sure no TODO's exist.
- [x] The specification on the writeup is aligned with the forum, snapshot, and the payload contract. If there are any changes, they are explicitly mentioned/communicated.
- [x] Minimal tests exist, and the snapshot diff report generated is the latest one and aligned with the payload.
- [ ] If deploy scripts are manually updated from the generated ones, I have carefully validated that they are correct, including the deploy commands and the proposal-creation script.
- [ ] If the aave-helpers submodule is updated, I have validated it is pointing to the latest version.
- [x] I have validated that no unused files and imports are being added.
- [ ] For an asset listing, the write-up includes a detailed specification of the price feed used, CAPO adapters (with each CAPO layer described separately), and eModes (with tables) if changed.
- [x] Wherever possible, I have validated that addresses from the address book are used instead of raw addresses.
-->
